### PR TITLE
Changed the conversion units for water vapour retrieval.

### DIFF
--- a/ULA3/dataset/_water_vapour_dataset.py
+++ b/ULA3/dataset/_water_vapour_dataset.py
@@ -99,7 +99,7 @@ class WaterVapourDataset(Dataset):
         wv_value_raw = super(WaterVapourDataset, self).get_data_value(longlat, nBand)
         logger.debug('Raw (scaled) water vapour value for %s = %s', longlat, wv_value_raw)
 
-        return 27.765 + wv_value_raw * 0.001 # Apply scale & offset to return correct units
+        return wv_value_raw * 0.1 # Convert from kg/m^2 to g/cm^2
 
 def main():
     """Main program for command-line utility.


### PR DESCRIPTION
The water vapour files changed their format, and well as the internally data scaling.  A change in the units conversion was required in order to correctly output g/cm^2.
