### PR TITLE
Build fortran modules purely through setup.py

### DIFF
--- a/gaip/setup.py
+++ b/gaip/setup.py
@@ -5,43 +5,99 @@ Setup
 This compiles all the Fortran extensions.
 """
 
-from numpy.distutils.core import Extension, setup
 
-setup(name='gaip',
-      ext_modules=[Extension(name='_cast_shadow_mask',
-                             sources=['cast_shadow_main.f90',
-                                      'terrain_border_margins.f90',
-                                      'cast_shadow_mask.f90',
-                                      'terrain_occlusion.f90',
-                                      'geo2metres_pixel_size.f90']),
-                   Extension(name='_exiting_angle',
-                             sources=['exiting_angle.f90',
-                                      'earth_rotation.f90']),
-                   Extension(name='_incident_angle',
-                             sources=['incident_angle.f90',
-                                      'earth_rotation.f90']),
-                   Extension(name='_slope_aspect',
-                             sources=['slope_aspect.f90',
-                                      'geo2metres_pixel_size.f90']),
-                   Extension(name='_surface_reflectance',
-                             sources=['surface_reflectance.f90',
-                                      'white_sky.f90',
-                                      'black_sky.f90',
-                                      'brdf_shape.f90']),
-                   Extension(name='_satellite_model',
-                             sources=['geo2metres_pixel_size.f90',
-                                      'satellite_model.f90']),
-                   Extension(name='_track_time_info',
-                             sources=['geod2geo.f90',
-                                      'q_cal.f90',
-                                      'geo2metres_pixel_size.f90',
-                                      'satellite_track.f90',
-                                      'track_time_info.f90']),
-                   Extension(name='_sat_sol_angles',
-                             sources=['solar_angle.f90',
-                                      'geod2geo.f90',
-                                      'q_cal.f90',
-                                      'compute_angles.f90',
-                                      'satellite_solar_angles_main.f90']),
-                   Extension(name='_interpolation',
-                             sources=['bilinear_interpolation.f90']) ])
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('gaip', parent_package, top_path)
+    config.add_data_files('sensors.json')
+    config.add_extension(
+        '_cast_shadow_mask',
+        [
+            'sys_variables.f90',
+            'cast_shadow_main.f90',
+            'terrain_border_margins.f90',
+            'cast_shadow_mask.f90',
+            'terrain_occlusion.f90',
+            'geo2metres_pixel_size.f90',
+        ]
+    ),
+    config.add_extension(
+        '_exiting_angle',
+        [
+            'sys_variables.f90',
+            'exiting_angle.f90',
+            'earth_rotation.f90',
+        ]
+    ),
+    config.add_extension(
+        '_incident_angle',
+        [
+            'incident_angle.f90',
+            'earth_rotation.f90',
+        ]
+    ),
+    config.add_extension(
+        '_slope_aspect',
+        [
+            'sys_variables.f90',
+            'slope_aspect.f90',
+            'geo2metres_pixel_size.f90',
+        ]
+    ),
+    config.add_extension(
+        '_surface_reflectance',
+        [
+            'surface_reflectance.f90',
+            'white_sky.f90',
+            'black_sky.f90',
+            'brdf_shape.f90',
+        ]
+    ),
+    config.add_extension(
+        '_satellite_model',
+        [
+            'sys_variables.f90',
+            'geo2metres_pixel_size.f90',
+            'satellite_model.f90',
+        ]
+    ),
+    config.add_extension(
+        '_track_time_info',
+        [
+            'sys_variables.f90',
+            'geod2geo.f90',
+            'q_cal.f90',
+            'geo2metres_pixel_size.f90',
+            'satellite_track.f90',
+            'track_time_info.f90',
+        ]
+    ),
+    config.add_extension(
+        '_sat_sol_angles',
+        [
+            'sys_variables.f90',
+            'solar_angle.f90',
+            'geod2geo.f90',
+            'q_cal.f90',
+            'compute_angles.f90',
+            'satellite_solar_angles_main.f90',
+        ]
+    ),
+    config.add_extension(
+        '_interpolation',
+        [
+            'bilinear_interpolation.f90',
+        ]
+    )
+    config.add_extension(
+        'unmiximage',
+        [
+            'unmiximage.f90',
+            'constants_NSWC.f90',
+            'nnls.f90',
+            'unmiximage.pyf',
+        ]
+    )
+
+    return config

--- a/gaip/unmiximage.pyf
+++ b/gaip/unmiximage.pyf
@@ -1,0 +1,34 @@
+!    -*- f90 -*-
+! Generated using `f2py -h unmiximage.pyf -m unmiximage unmiximage.f90`
+!
+! Note: the context of this file is case sensitive.
+
+python module unmiximage ! in 
+    interface  ! in :unmiximage
+        subroutine unmiximage(image,endmembermatrix,numbands,numendmembers,numrows,numcols,innull,outnull,fractionsimage) ! in :unmiximage:unmiximage.f90
+            use nonneg_leastsq
+            double precision dimension(numbands,numrows,numcols),intent(in) :: image
+            double precision dimension(numbands,numendmembers),intent(in),depend(numbands) :: endmembermatrix
+            integer, optional,intent(in),check(shape(image,0)==numbands),depend(image) :: numbands=shape(image,0)
+            integer, optional,intent(in),check(shape(endmembermatrix,1)==numendmembers),depend(endmembermatrix) :: numendmembers=shape(endmembermatrix,1)
+            integer, optional,intent(in),check(shape(image,1)==numrows),depend(image) :: numrows=shape(image,1)
+            integer, optional,intent(in),check(shape(image,2)==numcols),depend(image) :: numcols=shape(image,2)
+            double precision intent(in) :: innull
+            double precision intent(in) :: outnull
+            double precision dimension(numendmembers + 1,numrows,numcols),intent(out),depend(numendmembers,numrows,numcols) :: fractionsimage
+        end subroutine unmiximage
+        subroutine unmixpixel(pixelrefl,endmembermatrix,numbands,numendmembers,innull,outnull,pixelfractions) ! in :unmiximage:unmiximage.f90
+            use nonneg_leastsq
+            double precision dimension(numbands),intent(in) :: pixelrefl
+            double precision dimension(numbands,numendmembers),intent(in),depend(numbands) :: endmembermatrix
+            integer, optional,intent(in),check(len(pixelrefl)>=numbands),depend(pixelrefl) :: numbands=len(pixelrefl)
+            integer, optional,intent(in),check(shape(endmembermatrix,1)==numendmembers),depend(endmembermatrix) :: numendmembers=shape(endmembermatrix,1)
+            double precision intent(in) :: innull
+            double precision intent(in) :: outnull
+            double precision dimension(numendmembers + 1),intent(out),depend(numendmembers) :: pixelfractions
+        end subroutine unmixpixel
+    end interface 
+end python module unmiximage
+
+! This file was auto-generated with f2py (version:2).
+! See http://cens.ioc.ee/projects/f2py2e/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+"""
+Setup gaip
+"""
+
+from numpy.distutils.core import setup
+
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration(None, parent_package, top_path)
+    config.set_options(
+        ignore_setup_xxx_py=True,
+        assume_default_configuration=True,
+        delegate_options_to_subpackages=True,
+    )
+
+    config.add_subpackage('gaip')
+    # config.get_version('gaip/version.py') # sets config.version
+    return config
+
+
+setup(
+    name='gaip',
+    configuration=configuration,
+)


### PR DESCRIPTION
Adds a root setup.py, so that it can be installed without the makefile (I think i got everything?)

    python ./setup.py install

It needs more extensive testing, so over to you for comment Josh, but it builds and I can import gaip afterwards.
