### PR TITLE
Changed the luigi configs to use the disable_hard_timeout setting. It…

### DIFF
--- a/configs/luigi.cfg
+++ b/configs/luigi.cfg
@@ -17,11 +17,11 @@ invariant_height_fname = /g/data/v10/eoancillarydata/mars/daily-data/invariant/g
 # luigi config options
 [core]
 logging_conf_file = /some/path/to/logging/config
-max_reschedules = 0 # no re-submission of a failed task
 
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
+disable_hard_timeout = 600
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db

--- a/configs/luigi.cfg
+++ b/configs/luigi.cfg
@@ -21,7 +21,7 @@ logging_conf_file = /some/path/to/logging/config
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
-disable_hard_timeout = 600
+disable-hard-timeout = 600
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db

--- a/configs/multifile_example.cfg
+++ b/configs/multifile_example.cfg
@@ -37,7 +37,7 @@ logging_conf_file = /some/path/to/logging/config
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
-disable_hard_timeout = 120
+disable-hard-timeout = 120
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db

--- a/configs/multifile_example.cfg
+++ b/configs/multifile_example.cfg
@@ -33,11 +33,11 @@ buffer_distance = 7000 # overrides the default of 8000
 # luigi config options
 [core]
 logging_conf_file = /some/path/to/logging/config
-max_reschedules = 0 # no re-submission of a failed task
 
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
+disable_hard_timeout = 120
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db

--- a/configs/singlefile_example.cfg
+++ b/configs/singlefile_example.cfg
@@ -19,11 +19,11 @@ buffer_distance = 7000 # overrides the default of 8000
 # luigi config options
 [core]
 logging_conf_file = /some/path/to/logging/config
-max_reschedules = 0 # no re-submission of a failed task
 
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
+disable_hard_timeout = 600
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db

--- a/configs/singlefile_example.cfg
+++ b/configs/singlefile_example.cfg
@@ -23,7 +23,7 @@ logging_conf_file = /some/path/to/logging/config
 [scheduler]
 record_task_history = true
 state_path = luigi-state.pkl
-disable_hard_timeout = 600
+disable-hard-timeout = 600
 
 [task_history]
 db_connection = sqlite:///luigi-task-history.db


### PR DESCRIPTION
… refers to the time in seconds after a failed task occurs, that if it fails again after this period, then the task will be disabled.

Essentially the *max_reschedules* parameter didn't seem to be working, so this pull request changes the example luigi configs to utilise the [disable_hard_timeout](http://luigi.readthedocs.io/en/stable/configuration.html#scheduler) parameter.
A value of 600 is 600 seconds (10 mins).  If a task fails a second time and 600 seconds has passed since the first fail, the task **will** become disabled.
As a task re-submission time defaults to 15mins, then this enforces that a task will be attempted no more than twice.