### PR TITLE
Generic log names for semantic cross repo logging

### DIFF
--- a/configs/logging.cfg
+++ b/configs/logging.cfg
@@ -20,13 +20,13 @@ propagate=0
 [logger_waglError]
 level=ERROR
 handlers=errfileHandler
-qualname=wagl-error
+qualname=errors
 propagate=0
 
 [logger_waglStatus]
 level=INFO
 handlers=waglfileHandler
-qualname=wagl-status
+qualname=status
 propagate=0
 
 [handler_consoleHandler]
@@ -45,13 +45,13 @@ args=('luigi-interface.log',)
 class=FileHandler
 level=ERROR
 formatter=simpleFormatter
-args=('wagl-errors.log',)
+args=('errors.log',)
 
 [handler_waglfileHandler]
 class=FileHandler
 level=INFO
 formatter=simpleFormatter
-args=('wagl-status.log',)
+args=('status.log',)
 
 [formatter_simpleFormatter]
 format=%(asctime)s: %(levelname)s: %(message)s

--- a/wagl/ancillary.py
+++ b/wagl/ancillary.py
@@ -5,7 +5,6 @@ Ancillary dataset retrieval and storage
 """
 
 from __future__ import absolute_import, print_function
-import logging
 from os.path import join as pjoin, basename, splitext
 import datetime
 import glob
@@ -28,9 +27,6 @@ from wagl.hdf5 import attach_table_attributes
 from wagl.metadata import extract_ancillary_metadata, read_meatadata_tags
 from wagl.constants import DatasetName, POINT_FMT, GroupName, BandType
 from wagl.satellite_solar_angles import create_vertices
-
-
-log = logging.getLogger()
 
 
 ECWMF_LEVELS = [1, 2, 3, 5, 7, 10, 20, 30, 50, 70, 100, 125, 150, 175, 200,

--- a/wagl/multifile_workflow.py
+++ b/wagl/multifile_workflow.py
@@ -57,7 +57,7 @@ from wagl.pq import can_pq, _run_pq
 from wagl.hdf5 import create_external_link
 
 
-ERROR_LOGGER = wrap_logger(logging.getLogger('wagl-error'),
+ERROR_LOGGER = wrap_logger(logging.getLogger('errors'),
                            processors=[JSONRenderer(indent=1, sort_keys=True)])
 
 

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -35,7 +35,7 @@ from wagl.constants import Model, Method
 from wagl.standardise import card4l
 
 
-ERROR_LOGGER = wrap_logger(logging.getLogger('wagl-error'),
+ERROR_LOGGER = wrap_logger(logging.getLogger('errors'),
                            processors=[JSONRenderer(indent=1, sort_keys=True)])
 INTERFACE_LOGGER = logging.getLogger('luigi-interface')
 

--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -29,7 +29,7 @@ from wagl.slope_aspect import slope_aspect_arrays
 from wagl.temperature import surface_brightness_temperature
 from wagl.pq import can_pq, run_pq
 
-LOG = wrap_logger(logging.getLogger('wagl-status'),
+LOG = wrap_logger(logging.getLogger('status'),
                   processors=[JSONRenderer(indent=1, sort_keys=True)])
 
 


### PR DESCRIPTION
Update logging for wagl to be generic to make aggregation across wagl/tesp/eugl more semantic