### PR TITLE
HDF5 driver type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 dist: xenial
 language: python
 python:
-  - '3.5'
+  - '3.6'
 sudo: true
 
 cache:

--- a/configs/singlefile_example.cfg
+++ b/configs/singlefile_example.cfg
@@ -15,6 +15,7 @@ dem_path = /some/path/to/dem/data
 ecmwf_path = /some/path/to/ecmwf/daily/data
 invariant_height_fname = /some/path/to/invariant/height/dataset
 buffer_distance = 7000 # overrides the default of 8000
+h5_driver = core # overrides the default of direct write to disk; now write to memory then flush to disk when closing the file
 
 # luigi config options
 [core]

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -79,13 +79,13 @@ class Landsat5Scene1AcquisitionTest(unittest.TestCase):
             self.assertTrue(isinstance(acq, LandsatAcquisition))
 
     def test_band_type(self):
-        self.assertEqual(self.acqs[0].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[1].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[2].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[3].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[4].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[5].band_type, BandType.Thermal)
-        self.assertEqual(self.acqs[6].band_type, BandType.Reflective)
+        self.assertEqual(self.acqs[0].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[1].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[2].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[3].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[4].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[5].band_type, BandType.THERMAL)
+        self.assertEqual(self.acqs[6].band_type, BandType.REFLECTIVE)
 
     def test_acquisition_datetime(self):
         for acq in self.acqs:
@@ -157,14 +157,14 @@ class Landsat7Mtl1AcquisitionTest(unittest.TestCase):
             self.assertTrue(isinstance(acq, LandsatAcquisition))
 
     def test_band_type(self):
-        self.assertEqual(self.acqs[0].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[1].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[2].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[3].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[4].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[5].band_type, BandType.Thermal)
-        self.assertEqual(self.acqs[6].band_type, BandType.Thermal)
-        self.assertEqual(self.acqs[7].band_type, BandType.Reflective)
+        self.assertEqual(self.acqs[0].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[1].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[2].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[3].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[4].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[5].band_type, BandType.THERMAL)
+        self.assertEqual(self.acqs[6].band_type, BandType.THERMAL)
+        self.assertEqual(self.acqs[7].band_type, BandType.REFLECTIVE)
 
     def test_acquisition_datetime(self):
         for acq in self.acqs:
@@ -241,15 +241,15 @@ class Landsat8Mtl1AcquisitionTest(unittest.TestCase):
             self.assertTrue(isinstance(acq, Landsat8Acquisition))
 
     def test_band_type(self):
-        self.assertEqual(self.acqs[0].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[1].band_type, BandType.Thermal)
-        self.assertEqual(self.acqs[2].band_type, BandType.Thermal)
-        self.assertEqual(self.acqs[3].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[4].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[5].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[6].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[6].band_type, BandType.Reflective)
-        self.assertEqual(self.acqs[6].band_type, BandType.Reflective)
+        self.assertEqual(self.acqs[0].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[1].band_type, BandType.THERMAL)
+        self.assertEqual(self.acqs[2].band_type, BandType.THERMAL)
+        self.assertEqual(self.acqs[3].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[4].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[5].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[6].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[6].band_type, BandType.REFLECTIVE)
+        self.assertEqual(self.acqs[6].band_type, BandType.REFLECTIVE)
 
     def test_acquisition_datetime(self):
         for acq in self.acqs:

--- a/tests/test_lon_lat.py
+++ b/tests/test_lon_lat.py
@@ -37,8 +37,8 @@ class TestLonLatArrays(unittest.TestCase):
         acq = acquisitions(LS5_SCENE1).get_acquisitions()[0]
         geobox = acq.gridded_geo_box()
         fid = create_lon_lat_grids(acq, depth=5)
-        dataset_name = ppjoin(GroupName.lon_lat_group.value,
-                              DatasetName.lon.value)
+        dataset_name = ppjoin(GroupName.LON_LAT_GROUP.value,
+                              DatasetName.LON.value)
         lon = fid[dataset_name][:]
         ids = ut.random_pixel_locations(lon.shape)
 
@@ -82,8 +82,8 @@ class TestLonLatArrays(unittest.TestCase):
         acq = acquisitions(LS5_SCENE1).get_acquisitions()[0]
         geobox = acq.gridded_geo_box()
         fid = create_lon_lat_grids(acq, depth=5)
-        dataset_name = ppjoin(GroupName.lon_lat_group.value,
-                              DatasetName.lat.value)
+        dataset_name = ppjoin(GroupName.LON_LAT_GROUP.value,
+                              DatasetName.LAT.value)
         lat = fid[dataset_name][:]
         ids = ut.random_pixel_locations(lat.shape)
 

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -83,6 +83,7 @@ class DataStandardisation(luigi.Task):
     filter_opts = luigi.DictParameter(default=None, significant=False)
     acq_parser_hint = luigi.Parameter(default=None)
     buffer_distance = luigi.FloatParameter(default=8000, significant=False)
+    h5_driver = luigi.Parameter(default=None, significant=False)
 
     def output(self):
         fmt = '{label}.wagl.h5'
@@ -105,7 +106,7 @@ class DataStandardisation(luigi.Task):
                    self.dem_path, self.dsm_fname, self.invariant_height_fname,
                    self.modtran_exe, out_fname, ecmwf_path, self.rori,
                    self.buffer_distance, self.compression, self.filter_opts,
-                   self.acq_parser_hint)
+                   self.h5_driver, self.acq_parser_hint)
 
 
 @inherits(DataStandardisation)
@@ -148,7 +149,8 @@ class ARD(luigi.WrapperTask):
                           'rori': self.rori,
                           'compression': self.compression,
                           'filter_opts': self.filter_opts,
-                          'buffer_distance': self.buffer_distance}
+                          'buffer_distance': self.buffer_distance,
+                          'h5_driver': self.h5_driver}
                 yield DataStandardisation(**kwargs)
 
         

--- a/wagl/standardise.py
+++ b/wagl/standardise.py
@@ -40,11 +40,128 @@ def card4l(level1, granule, model, vertices, method, pixel_quality, landsea,
            water_vapour, dem_path, dsm_fname, invariant_fname, modtran_exe,
            out_fname, ecmwf_path=None, rori=0.52, buffer_distance=8000,
            compression=H5CompressionFilter.LZF, filter_opts=None,
-           acq_parser_hint=None):
+           h5_driver=None, acq_parser_hint=None):
     """
     CEOS Analysis Ready Data for Land.
     A workflow for producing standardised products that meet the
     CARD4L specification.
+
+    :param level1:
+        A string containing the full file pathname to the level1
+        dataset.
+
+    :param granule:
+        A string containing the granule id to process.
+
+    :param model:
+        An enum from wagl.constants.Model representing which
+        workflow model to run.
+
+    :param vertices:
+        An integer 2-tuple indicating the number of rows and columns
+        of sample-locations ("coordinator") to produce.
+        The vertex columns should be an odd number.
+
+    :param method:
+        An enum from wagl.constants.Method representing the
+        interpolation method to use during the interpolation
+        of the atmospheric coefficients.
+
+    :param pixel_quality:
+        A bool indicating whether or not to run pixel quality.
+
+    :param landsea:
+        A string containing the full file pathname to the directory
+        containing the land/sea mask datasets.
+
+    :param tle_path:
+        A string containing the full file pathname to the directory
+        containing the two line element datasets.
+
+    :param aerosol:
+        A string containing the full file pathname to the HDF5 file
+        containing the aerosol data.
+
+    :param brdf_path:
+        A string containing the full file pathname to the directory
+        containing the BRDF data.
+
+    :param brdf_premodis_path:
+        A string containing the full file pathname to the directory
+        containing the decadal averaged BRDF data used for acquisitions
+        prior to TERRA/AQUA satellite operations, or for near real time
+        applications.
+
+    :param ozone_path:
+        A string containing the full file pathname to the directory
+        containing the ozone datasets.
+
+    :param water_vapour:
+        A string containing the full file pathname to the directory
+        containing the water vapour datasets.
+
+    :param dem_path:
+        A string containing the full file pathname to the directory
+        containing the reduced resolution DEM.
+
+    :param dsm_path:
+        A string containing the full file pathname to the directory
+        containing the Digital Surface Model for use in terrain
+        illumination correction.
+
+    :param invariant_fname:
+        A string containing the full file pathname to the image file
+        containing the invariant geo-potential data for use within
+        the SBT process.
+
+    :param modtran_exe:
+        A string containing the full file pathname to the MODTRAN
+        executable.
+
+    :param out_fname:
+        A string containing the full file pathname that will contain
+        the output data from the data standardisation process.
+        executable.
+
+    :param ecmwf_path:
+        A string containing the full file pathname to the directory
+        containing the data from the European Centre for Medium Weather
+        Forcast, for use within the SBT process.
+
+    :param rori:
+        A floating point value for surface reflectance adjustment.
+        TODO Fuqin to add additional documentation for this parameter.
+        Default is 0.52.
+
+    :param buffer_distance:
+        A number representing the desired distance (in the same
+        units as the acquisition) in which to calculate the extra
+        number of pixels required to buffer an image.
+        Default is 8000, which for an acquisition using metres would
+        equate to 8000 metres.
+
+    :param compression:
+        An enum from hdf5.compression.H5CompressionFilter representing
+        the desired compression filter to use for writing H5 IMAGE and
+        TABLE class datasets to disk.
+        Default is H5CompressionFilter.LZF.
+
+    :param filter_opts:
+        A dict containing any additional keyword arguments when
+        generating the configuration for the given compression Filter.
+        Default is None.
+
+    :param h5_driver:
+        The specific HDF5 file driver to use when creating the output
+        HDF5 file.
+        See http://docs.h5py.org/en/latest/high/file.html#file-drivers
+        for more details.
+        Default is None; which writes direct to disk using the
+        appropriate driver for the underlying OS.
+
+    :param acq_parser_hint:
+        A string containing any hints to provide the acquisitions
+        loader with.
     """
     tp5_fmt = pjoin(POINT_FMT, ALBEDO_FMT, ''.join([POINT_ALBEDO_FMT, '.tp5']))
     nvertices = vertices[0] * vertices[1]
@@ -52,7 +169,7 @@ def card4l(level1, granule, model, vertices, method, pixel_quality, landsea,
     container = acquisitions(level1, hint=acq_parser_hint)
 
     # TODO: pass through an acquisitions container rather than pathname
-    with h5py.File(out_fname, 'w') as fid:
+    with h5py.File(out_fname, 'w', driver=h5_driver) as fid:
         fid.attrs['level1_uri'] = level1
 
         for grp_name in container.supported_groups:


### PR DESCRIPTION
This pull request adds an extra config param to the singlefile_workflow and to the the card4l func, that allows the user to specify a HDF5 file driver type.

See [HDF5 file drivers](http://docs.h5py.org/en/latest/high/file.html#file-drivers) for more info.

The reason was to enable the in-memory file like driver, that flushes to disk only when the memory file is closed. This has benefit on large scale processing where the underlying file system may get overworked with lots of little continual writes for 10's of 1000's of open files. Testing on NCI has also shown a processing speedup which decreases costs.

This has only been enabled for the singlefile_workflow.  I'm not expecting much if any benefit for the multifile_workflow.

Also adds docs to the card4l function.