### PR TITLE
Feature/add timezones to md

### DIFF
--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -62,6 +62,14 @@ def extract_ancillary_metadata(fname):
     return res
 
 
+def get_system_information():
+    utc_now = dtime.utcnow().replace(tzinfo=dtz.utc).isoformat()
+    system_info = {'uname': ' '.join(os.uname()),
+                   'hostname': socket.getfqdn(),
+                   'runtime_id': str(uuid.uuid1()),
+                   'time_processed': utc_now}
+
+
 def read_meatadata_tags(fname, bands):
     """
     Retrieves the metadata tags for a list of bands from a `GDAL`
@@ -254,12 +262,7 @@ def create_ard_yaml(acquisitions, ancillary_group, out_group, sbt=False):
         algorithm['nbar_doi'] = 'http://dx.doi.org/10.1109/JSTARS.2010.2042281'
         algorithm['nbar_terrain_corrected_doi'] = 'http://dx.doi.org/10.1016/j.rse.2012.06.018' # pylint: disable=line-too-long
 
-    system_info = {'uname': ' '.join(os.uname()),
-                   'hostname': socket.getfqdn(),
-                   'runtime_id': str(uuid.uuid1()),
-                   'time_processed': dtime.utcnow().isoformat()}
-
-    metadata = {'system_information': system_info,
+    metadata = {'system_information': get_system_information(),
                 'source_datasets': source_info,
                 'ancillary': ancillary,
                 'algorithm_information': algorithm,
@@ -291,11 +294,6 @@ def create_pq_yaml(acquisition, ancillary, tests_run, out_group):
     :return:
         None; The yaml document is written to the HDF5 file.
     """
-    utc_now = dtime.utcnow().replace(tzinfo=dtz.utc).isoformat()
-    system_info = {'uname': ' '.join(os.uname()),
-                   'hostname': socket.getfqdn(),
-                   'runtime_id': str(uuid.uuid1()),
-                   'time_processed': utc_now}
 
     source_info = {'source_l1t': dirname(acquisition.dir_name),
                    'source_reflectance': 'NBAR'}
@@ -304,7 +302,7 @@ def create_pq_yaml(acquisition, ancillary, tests_run, out_group):
                  'software_repository': 'https://github.com/GeoscienceAustralia/wagl.git', # pylint: disable=line-too-long
                  'pq_doi': 'http://dx.doi.org/10.1109/IGARSS.2013.6723746'}
     
-    metadata = {'system_information': system_info,
+    metadata = {'system_information': get_system_information(),
                 'source_data': source_info,
                 'algorithm_information': algorithm,
                 'ancillary': ancillary,

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -68,6 +68,7 @@ def get_system_information():
                    'hostname': socket.getfqdn(),
                    'runtime_id': str(uuid.uuid1()),
                    'time_processed': utc_now}
+    return system_info
 
 
 def read_meatadata_tags(fname, bands):


### PR DESCRIPTION
Changes timestamps on system and ancillary to include information on timezone (+00:00 by default for a datetime with a timezone set in python).

Justification: Output metadata file should be consumable by any language; not just python. Imagery metadata information already includes information around timezone/utc.

Query/Discussion:
* The default implementation of python's isoformat will output a timezone as an offset (for UTC it's +00:00), however existing timestamps where a timezone has been coerced output "Z" (added in when formatting the timestamp to a string.
* Should we use the default of python's isoformat? Or append "Z" to utc timestamps produced by wagl?