### PR TITLE
Adding root reference to archive names for gdal

### DIFF
--- a/wagl/acquisition/__init__.py
+++ b/wagl/acquisition/__init__.py
@@ -438,7 +438,9 @@ def acquisitions_via_safe(pathname):
         granule_root = ElementTree.XML(granule_xml)
 
         # handling different metadata versions for image paths
-        img_data_path = ''.join(['zip:', pathname, '!', archive.namelist()[0]])
+        # files retrieved from archive.namelist are not prepended with a '/'
+        # Rasterio 1.0b1 requires archive paths start with a /
+        img_data_path = ''.join(['zip:', pathname, '!/', archive.namelist()[0]])
         if basename(images[0]) == images[0]:
             img_data_path = ''.join([img_data_path,
                                      pjoin('GRANULE', granule_id, 'IMG_DATA')])


### PR DESCRIPTION
* Based on the VFS documentation paths inside an archive should be absolute paths; the examples show this starting with a "/" after "!"
* In rasterio 1.0b1 there is a change in behaviour where references inside an archive that lacked a "/" after "!" were failing to be found.
* Apache VFS documentation: https://commons.apache.org/proper/commons-vfs/filesystems.html#Zip_Jar_and_Tar