### PR TITLE
commit travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 
 install:
   - pip install wheel numpy
+  - pip install GDAL==$(gdal-config --version) --global-option=build_ext
   - pip install --process-dependency-links .
   - pip install --upgrade pip setuptools pytest pytest-runner
   - pip install --pre --upgrade rasterio>0.9


### PR DESCRIPTION
* Installs GDAL python bindings from gdal version installed via ubuntugis

Kind of a hack installing it outside of the setup.py; but the binding has to match the parent lib and if the local version is outside what is specified by WAGL we should still see a build failure.