### PR TITLE
Remove name capture from ancillary metadata

### DIFF
--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -58,7 +58,7 @@ def extract_ancillary_metadata(fname):
     res['ctime'] = _get_utc_datetime(fstat.st_ctime)
     res['mtime'] = _get_utc_datetime(fstat.st_mtime)
     res['atime'] = _get_utc_datetime(fstat.st_atime)
-    res['owner'] = pwd.getpwuid(fstat.st_uid).pw_gecos
+    res['owner_id'] = str(fstat.st_uid)
     return res
 
 


### PR DESCRIPTION
* Migrates from capturing the username to the user_id in the distributed metadata for ancillary source files.