### PR TITLE
Fix convert aot

### DIFF
--- a/wagl/scripts/aot_converter.py
+++ b/wagl/scripts/aot_converter.py
@@ -30,6 +30,8 @@ def read_pix(filename):
                           count=recs[2] * 3).reshape(3, recs[2])
     time = numpy.fromfile(src, dtype='int16',
                           count=recs[2] * 3).reshape(3, recs[2])
+    lat = numpy.fromfile(src, dtype='float32', count=recs[2])
+    lon = numpy.fromfile(src, dtype='float32', count=recs[2])
     aot = numpy.fromfile(src, dtype='float32', count=recs[2])
     src.close()
 


### PR DESCRIPTION
Two lines were previously removed for a pylint cleanup.  However, as we're seeking through a binary file via implicit reading into variables, we'll not retrieve correct data for variables that follow on from these _missing_ variables.

Code wise it is simpler to just read the data, and make it clear to the reader what those sections within the binary blob refer to.

In short, I've put the two lines back in.