### PR TITLE
Feature/pandas df tz aware

### DIFF
--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -363,12 +363,15 @@ class HDF5Test(unittest.TestCase):
         tested.
         """
         df = pandas.DataFrame(self.table_data)
-        df['timestamps'] = pandas.date_range('1/1/2000', periods=10, freq='D')
+        df['timestamps'] = pandas.date_range('1/1/2000', periods=10, freq='D', tz='UTC')
         df['string_data'] = ['period {}'.format(i) for i in range(10)]
 
         fname = 'test_dataframe_roundtrip.h5'
         with h5py.File(fname, **self.memory_kwargs) as fid:
             hdf5.write_dataframe(df, 'dataframe', fid)
+            # Apply conversion to no timezone that occurs in serialisation to hdf5
+            # Numpy is timezone naive; pandas has timezone support
+            df['timestamps'] = df['timestamps'].dt.tz_convert(None)
             self.assertTrue(df.equals(hdf5.read_h5_table(fid, 'dataframe')))
 
 

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -6,6 +6,7 @@ such as images and tables, as well as attaching metadata.
 """
 
 import datetime
+import re
 from functools import partial
 from pprint import pprint
 
@@ -309,10 +310,14 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
         elif idx_name is None:
             idx_name = default_label.format(i)
         idx_names.append(idx_name)
-        dtype_metadata['{}_dtype'.format(idx_name)] = idx_data.dtype.name
-        if idx_data.dtype.name == 'object':
+        _dtype_name = idx_data.dtype.name
+        if 'datetime64' in _dtype_name:
+            # Pandas supports timezones but numpy does not; remove timezone
+            _dtype = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
+        dtype_metadata['{}_dtype'.format(idx_name)] = _dtype_name
+        if _dtype_name == 'object':
             dtype.append((idx_name, VLEN_STRING))
-        elif 'datetime64' in idx_data.dtype.name:
+        elif 'datetime64' in _dtype_name:
             dtype.append((idx_name, 'int64'))
         else:
             dtype.append((idx_name, idx_data.dtype))
@@ -320,10 +325,14 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
     # column datatypes
     for i, val in enumerate(df.dtypes):
         col_name = df.columns[i]
-        dtype_metadata['{}_dtype'.format(col_name)] = val.name
-        if val.name == 'object':
+        _dtype_name = val.name
+        if 'datetime64' in _dtype_name:
+            # Pandas supports timezones but numpy does not; remove timezone
+            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype)
+        dtype_metadata['{}_dtype'.format(col_name)] = _dtype_name
+        if _dtype_name == 'object':
             dtype.append((col_name, VLEN_STRING))
-        elif ('datetime64' in val.name) or ('timedelta64' in val.name):
+        elif ('datetime64' in _dtype_name) or ('timedelta64' in _dtype_name):
             dtype.append((col_name, 'int64'))
         else:
             dtype.append((col_name, val))
@@ -378,7 +387,7 @@ def read_h5_table(fid, dataset_name, dataframe=True):
     Read a HDF5 `TABLE` as a `pandas.DataFrame`.
 
     :param fid:
-        A h5py `Group` or `File` object from which to write the
+        A h5py `Group` or `File` object from which to read the
         dataset from.
 
     :param dataset_name:

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -313,7 +313,7 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
         _dtype_name = idx_data.dtype.name
         if 'datetime64' in _dtype_name:
             # Pandas supports timezones but numpy does not; remove timezone
-            _dtype = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
+            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
         dtype_metadata['{}_dtype'.format(idx_name)] = _dtype_name
         if _dtype_name == 'object':
             dtype.append((idx_name, VLEN_STRING))
@@ -328,7 +328,7 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
         _dtype_name = val.name
         if 'datetime64' in _dtype_name:
             # Pandas supports timezones but numpy does not; remove timezone
-            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype)
+            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
         dtype_metadata['{}_dtype'.format(col_name)] = _dtype_name
         if _dtype_name == 'object':
             dtype.append((col_name, VLEN_STRING))


### PR DESCRIPTION
* Removes timezone when table is serialized to hdf5, alter test to account for conversion to numpy timezone naive datetimes. 