### PR TITLE
uuid1 -> uuid4

### DIFF
--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -289,7 +289,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                 'ancillary': ancillary(ancillary_group),
                 'algorithm_information': algorithm(),
                 'software_versions': software_versions(),
-                'id': str(uuid.uuid1()),
+                'id': str(uuid.uuid4()),
                 'parameters': parameters}
 
     # output


### PR DESCRIPTION
As per @ASVincent 's comments, changed `uuid1` to safer `uuid4`.