### PR TITLE
Solar constant

### DIFF
--- a/wagl/acquisition/sentinel.py
+++ b/wagl/acquisition/sentinel.py
@@ -174,7 +174,7 @@ class Sentinel2Acquisition(Acquisition):
         solar_zenith = numpy.float32(rbspline(y, x, solar_zenith))
         self._solar_zenith = numpy.radians(solar_zenith, out=solar_zenith)
 
-    def radiance_data(self, window=None, out_no_data=-999):
+    def radiance_data(self, window=None, out_no_data=-999, esun=None):
         """
         Return the data as radiance in watts/(m^2*micrometre).
 


### PR DESCRIPTION
Missed esun parameter in sentinel-2 acquisition class in earlier merge. There is esun variables already present within a  radiance_data method in a sentinel-2 acquisition class. The esun value we passed gets overwritten, which works out for current case because esun value we passed gets only used for landsat-8. 