### PR TITLE
BRDF ocean mask

### DIFF
--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -305,11 +305,12 @@ def load_brdf_tile(src_poly, src_crs, fid, dataset_name, fid_mask):
     roi_mask = roi_mask.astype(bool)
 
     # both ocean_mask and mask shape should be same
-    assert ocean_mask.shape == roi_mask.shape
+    if ocean_mask.shape != roi_mask.shape:
+        raise ValueError('ocean mask and ROI mask do not have the same shape')
+    if roi_mask.shape != ds.shape[-2:]:
+        raise ValueError('BRDF dataset and ROI mask do not have the same shape')
 
     roi_mask = roi_mask & ocean_mask
-
-    assert roi_mask.shape == ds.shape[-2:]
 
     def layer_sum(i):
         layer = ds[i, :, :]

--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -297,7 +297,9 @@ def load_brdf_tile(src_poly, src_crs, fid, dataset_name, is_fallback, fid_mask):
         return BrdfTileSummary.empty()
 
     mask = rasterize([(dst_poly, 1)], fill=0, out_shape=(ds_width, ds_height), transform=dst_geotransform)
-    assert ocean_mask.shape == mask.shape    # shape should be same 
+    
+    # both ocean_data and mask shape should be same
+    assert ocean_data.shape == mask.shape 
     
     # if both ocean_data (1=land, 0=ocean) and dst_poly (1=valid, 0=invalid)
     # then multiplying two masks would result in 1 being if both masks are true
@@ -309,7 +311,6 @@ def load_brdf_tile(src_poly, src_crs, fid, dataset_name, is_fallback, fid_mask):
 
     def layer_sum(i):
         #TODO Discuss with Imam: should we compute individual number of valid pixels for each BRDF parameter? 
-
         layer = ds[i, :, :]
         fill_value_mask = (layer != ds.attrs['_FillValue'])
         layer = layer.astype('float32')
@@ -335,21 +336,21 @@ def get_brdf_data(acquisition, brdf,
 
     :param brdf:
         A `dict` defined as either of the following:
-
         * {'user': {<band-alias>: {'iso': <value>, 'vol': <value>, 'geo': <value>}, ...}}
-        * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>, 'ocean_mask_path': <path-to-ocean-mask>}
+        * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>, 
+           'ocean_mask_path': <path-to-ocean-mask>}
         
         Here <path-to-BRDF> is a string containing the full file system
         path to your directory containing the ource BRDF files
         The BRDF directories are assumed to be yyyy.mm.dd naming convention.
 
-        And <path-to-average-BRDF> is a string containing the full file system
+        <path-to-average-BRDF> is a string containing the full file system
         path to your directory containing the Jupp-Li backup BRDF data.
         To be used for pre-MODIS and potentially post-MODIS acquisitions.
 
         And <path-to-ocean-mask> is a string containing the full file system path
         to your ocean mask file. To be used for masking ocean pixels from  BRDF data 
-        from pre-MODIS and post-MODIS acquisitions. 
+        all acquisitions. 
   
     :param compression:
         The compression filter to use.

--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -264,7 +264,7 @@ def valid_region(fname, mask_value=None):
     return geom, crs
 
 
-def load_brdf_tile(src_poly, src_crs, fid, dataset_name, is_fallback, fid_mask):
+def load_brdf_tile(src_poly, src_crs, fid, dataset_name, fid_mask):
     """
     Summarize BRDF data from a single tile.
     """
@@ -280,12 +280,12 @@ def load_brdf_tile(src_poly, src_crs, fid, dataset_name, is_fallback, fid_mask):
     dst_geotransform = rasterio.transform.Affine.from_gdal(*ds.attrs['geotransform'])
     dst_crs = CRS.from_wkt(ds.attrs['crs_wkt'])
 
-    # get bounds of BRDF modis tile from h5 dataset 
+    # get bounds of BRDF modis tile from h5 dataset
     left, bottom, right, top = rasterio.transform.array_bounds(ds_height, ds_width, dst_geotransform)
-    
-    # get a tile window to read from continental coastal mask 
+
+    # get a tile window to read from continental coastal mask
     window = rasterio.windows.from_bounds(left, bottom, right, top, transform=fid_mask.transform)
-    
+
     # read ocean mask file for correspoing tile window
     ocean_data = fid_mask.read(1, window=window)
     # assumes the length scales are the same (m)
@@ -297,20 +297,20 @@ def load_brdf_tile(src_poly, src_crs, fid, dataset_name, is_fallback, fid_mask):
         return BrdfTileSummary.empty()
 
     mask = rasterize([(dst_poly, 1)], fill=0, out_shape=(ds_width, ds_height), transform=dst_geotransform)
-    
+
     # both ocean_data and mask shape should be same
-    assert ocean_data.shape == mask.shape 
-    
+    assert ocean_data.shape == mask.shape
+
     # if both ocean_data (1=land, 0=ocean) and dst_poly (1=valid, 0=invalid)
     # then multiplying two masks would result in 1 being if both masks are true
     mask = mask * ocean_data
-    
+
     valid_pixels = np.sum(mask)
     mask = mask.astype(bool)
-    assert mask.shape == ds.shape[:-2]
+    assert mask.shape == ds.shape[-2:]
 
     def layer_sum(i):
-        #TODO Discuss with Imam: should we compute individual number of valid pixels for each BRDF parameter? 
+        # TODO Discuss with Imam: should we compute individual number of valid pixels for each BRDF parameter?
         layer = ds[i, :, :]
         fill_value_mask = (layer != ds.attrs['_FillValue'])
         layer = layer.astype('float32')
@@ -337,9 +337,9 @@ def get_brdf_data(acquisition, brdf,
     :param brdf:
         A `dict` defined as either of the following:
         * {'user': {<band-alias>: {'iso': <value>, 'vol': <value>, 'geo': <value>}, ...}}
-        * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>, 
+        * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>,
            'ocean_mask_path': <path-to-ocean-mask>}
-        
+
         Here <path-to-BRDF> is a string containing the full file system
         path to your directory containing the ource BRDF files
         The BRDF directories are assumed to be yyyy.mm.dd naming convention.
@@ -349,9 +349,9 @@ def get_brdf_data(acquisition, brdf,
         To be used for pre-MODIS and potentially post-MODIS acquisitions.
 
         And <path-to-ocean-mask> is a string containing the full file system path
-        to your ocean mask file. To be used for masking ocean pixels from  BRDF data 
-        all acquisitions. 
-  
+        to your ocean mask file. To be used for masking ocean pixels from  BRDF data
+        all acquisitions.
+
     :param compression:
         The compression filter to use.
         Default is H5CompressionFilter.LZF
@@ -389,7 +389,7 @@ def get_brdf_data(acquisition, brdf,
     brdf_primary_path = brdf['brdf_path']
     brdf_secondary_path = brdf['brdf_premodis_path']
     brdf_ocean_mask_path = brdf['ocean_mask_path']
-    
+
     # Get the date of acquisition
     dt = acquisition.acquisition_datetime.date()
 
@@ -426,10 +426,10 @@ def get_brdf_data(acquisition, brdf,
     tally = {}
     with rasterio.open(brdf_ocean_mask_path, 'r') as fid_mask:
         for ds in acquisition.brdf_datasets:
-            tally[ds] = BrdfTileSummary.empty(fallback_brdf)
+            tally[ds] = BrdfTileSummary.empty()
             for tile in tile_list:
                 with h5py.File(tile, 'r') as fid:
-                    tally[ds] += load_brdf_tile(src_poly, src_crs, fid, ds, fallback_brdf, fid_mask)
+                    tally[ds] += load_brdf_tile(src_poly, src_crs, fid, ds, fid_mask)
             tally[ds] = tally[ds].mean()
 
     results = {param: dict(data_source='BRDF',

--- a/wagl/brdf.py
+++ b/wagl/brdf.py
@@ -337,9 +337,8 @@ def get_brdf_data(acquisition, brdf,
         A `dict` defined as either of the following:
 
         * {'user': {<band-alias>: {'iso': <value>, 'vol': <value>, 'geo': <value>}, ...}}
-        * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>}
-
         * {'brdf_path': <path-to-BRDF>, 'brdf_premodis_path': <path-to-average-BRDF>, 'ocean_mask_path': <path-to-ocean-mask>}
+        
         Here <path-to-BRDF> is a string containing the full file system
         path to your directory containing the ource BRDF files
         The BRDF directories are assumed to be yyyy.mm.dd naming convention.

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -365,9 +365,9 @@ def current_h5_metadata(fid: h5py.Group, dataset_path: str = ""):
         A dictionary representation of the dataset metadata
     """
 
-    metadata = fid.get('/{}{}/{}'.format(
+    metadata = fid.get('/{}/{}/{}'.format(
         DatasetName.METADATA.value,
-        dataset_path,
+        dataset_path.lstrip('/'),
         DatasetName.CURRENT_METADATA.value
     ))
 


### PR DESCRIPTION
Success!

Runs end-to-end, applies ocean mask (implemented by @passangd), ancillary metadata reporting for BRDF now conforms with the others.

The final metadata output should possibly be improved (in tesp?). Validation for pan-chromatic as well as BRDF is needed.

I know that the tests for reading DEM outside the bounds is broken. Maybe later.