### PR TITLE
Fix read subset

### DIFF
--- a/tests/test_read_subset.py
+++ b/tests/test_read_subset.py
@@ -204,9 +204,9 @@ class TestReadSubset(unittest.TestCase):
 
     def test_case_a(self):
         """
-        Origin = (-150, -50)
+        Origin = (-150, -50); `O`
 
-            +----+
+           O+----+
             -    -
             -  +-----------+
             -  - -         -
@@ -232,14 +232,14 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 50 * 250
         self.assertTrue(data.sum() == count)
 
     def test_case_b(self):
         """
-        Origin = (-150, 600)
+        Origin = (-150, 600); `O`
 
-            +---+
+           O+---+
             -   -
         +----   ----+
         -   -   -   -
@@ -265,14 +265,14 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 50 * 300
         self.assertTrue(data.sum() == count)
 
     def test_case_c(self):
         """
-        Origin = (-150, 1400)
+        Origin = (-150, 1400); `O`
 
-                   +---+
+                  O+---+
                    -   -
         +------------+ -
         -          - - -
@@ -298,16 +298,16 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 50 * 100
         self.assertTrue(data.sum() == count)
 
     def test_case_d(self):
         """
-        Origin = (600, -50)
+        Origin = (600, -50); `O`
 
               +-----------+
               -           -
-           +-----+        -
+          O+-----+        -
            -  -  -        -
            -  -  -        -
            +-----+        -
@@ -329,16 +329,16 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 200 * 250
         self.assertTrue(data.sum() == count)
 
     def test_case_e(self):
         """
-        Origin = (600, 600)
+        Origin = (600, 600); `O`
 
         +-----------+
         -           -
-        -   +---+   -
+        -  O+---+   -
         -   -   -   -
         -   -   -   -
         -   +---+   -
@@ -360,16 +360,16 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = self.subs_shape[0] * self.subs_shape[1]
+        count = 200 * 300
         self.assertTrue(data.sum() == count)
 
     def test_case_f(self):
         """
-        Origin = (600, 1400)
+        Origin = (600, 1400); `O`
 
         +-----------+
         -           -
-        -        +-----+
+        -       O+-----+
         -        -  -  -
         -        -  -  -
         -        +-----+
@@ -391,19 +391,19 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 200 * 100
         self.assertTrue(data.sum() == count)
 
     def test_case_g(self):
         """
-        Origin = (1100, -50)
+        Origin = (1100, -50); `O`
 
               +-----------+
               -           -
               -           -
               -           -
               -           -
-           +-----+        -
+          O+-----+        -
            -  -  -        -
            -  +-----------+
            -     -
@@ -425,19 +425,19 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 100 * 250
         self.assertTrue(data.sum() == count)
 
     def test_case_h(self):
         """
-        Origin = (1100, 600)
+        Origin = (1100, 600); `O`
 
         +-----------+
         -           -
         -           -
         -           -
         -           -
-        -   +----+  -
+        -  O+----+  -
         -   -    -  -
         +-----------+
             -    -
@@ -459,19 +459,19 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 100 * 300
         self.assertTrue(data.sum() == count)
 
     def test_case_i(self):
         """
-        Origin = (1100, 1400)
+        Origin = (1100, 1400); `O`
 
         +-----------+
         -           -
         -           -
         -           -
         -           -
-        -        +-----+
+        -       O+-----+
         -        -     -
         +-----------+---
                  -     -
@@ -493,7 +493,7 @@ class TestReadSubset(unittest.TestCase):
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
 
-        count = 
+        count = 100 * 100
         self.assertTrue(data.sum() == count)
 
 if __name__ == '__main__':

--- a/tests/test_read_subset.py
+++ b/tests/test_read_subset.py
@@ -7,6 +7,7 @@ import tempfile
 import unittest
 
 import numpy
+import h5py
 
 from wagl.data import read_subset
 from wagl.data import write_img
@@ -14,6 +15,17 @@ from wagl import unittesting_tools as ut
 
 
 class TestReadSubset(unittest.TestCase):
+
+    img, geobox = ut.create_test_image((1200, 1500))
+    img[:] = 1
+
+    fid = h5py.File('test-subset.h5', backing_store=False, driver='core')
+    ds = fid.create_dataset('data', data=img)
+    ds.attrs['geotransform'] = geobox.transform.to_gdal()
+    ds.attrs['crs_wkt'] = geobox.crs.ExportToWkt()
+    ds.attrs['fillvalue'] = 0
+
+    subs_shape = (200, 300)
 
     @unittest.skip("Refactor DSM subsetting logic; TODO update test")
     def testWestBounds(self):
@@ -190,6 +202,299 @@ class TestReadSubset(unittest.TestCase):
         # Cleanup
         shutil.rmtree(temp_dir)
 
+    def test_case_a(self):
+        """
+        Origin = (-150, -50)
+
+            +----+
+            -    -
+            -  +-----------+
+            -  - -         -
+            +----+         -
+               -           -
+               -           -
+               -           -
+               -           -
+               +-----------+
+        """
+        # indices based on full array
+        ul = (-150, -50)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_b(self):
+        """
+        Origin = (-150, 600)
+
+            +---+
+            -   -
+        +----   ----+
+        -   -   -   -
+        -   +---+   -
+        -           -
+        -           -
+        -           -
+        -           -
+        +-----------+
+        """
+        # indices based on full array
+        ul = (-150, 600)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_c(self):
+        """
+        Origin = (-150, 1400)
+
+                   +---+
+                   -   -
+        +------------+ -
+        -          - - -
+        -          +---+
+        -            -
+        -            -
+        -            -
+        -            -
+        +------------+
+        """
+        # indices based on full array
+        ul = (-150, 1400)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_d(self):
+        """
+        Origin = (600, -50)
+
+              +-----------+
+              -           -
+           +-----+        -
+           -  -  -        -
+           -  -  -        -
+           +-----+        -
+              -           -
+              +-----------+
+        """
+        # indices based on full array
+        ul = (600, -50)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_e(self):
+        """
+        Origin = (600, 600)
+
+        +-----------+
+        -           -
+        -   +---+   -
+        -   -   -   -
+        -   -   -   -
+        -   +---+   -
+        -           -
+        +-----------+
+        """
+        # indices based on full array
+        ul = (600, 600)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = self.subs_shape[0] * self.subs_shape[1]
+        self.assertTrue(data.sum() == count)
+
+    def test_case_f(self):
+        """
+        Origin = (600, 1400)
+
+        +-----------+
+        -           -
+        -        +-----+
+        -        -  -  -
+        -        -  -  -
+        -        +-----+
+        -           -
+        +-----------+
+        """
+        # indices based on full array
+        ul = (600, 1400)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_g(self):
+        """
+        Origin = (1100, -50)
+
+              +-----------+
+              -           -
+              -           -
+              -           -
+              -           -
+           +-----+        -
+           -  -  -        -
+           -  +-----------+
+           -     -
+           -     -
+           +-----+
+        """
+        # indices based on full array
+        ul = (1100, -50)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_h(self):
+        """
+        Origin = (1100, 600)
+
+        +-----------+
+        -           -
+        -           -
+        -           -
+        -           -
+        -   +----+  -
+        -   -    -  -
+        +-----------+
+            -    -
+            -    -
+            +----+
+        """
+        # indices based on full array
+        ul = (1100, 600)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
+
+    def test_case_i(self):
+        """
+        Origin = (1100, 1400)
+
+        +-----------+
+        -           -
+        -           -
+        -           -
+        -           -
+        -        +-----+
+        -        -     -
+        +-----------+---
+                 -     -
+                 -     -
+                 +-----+
+        """
+        # indices based on full array
+        ul = (1100, 1400)
+        ur = (ul[0], ul[1] + self.subs_shape[1])
+        lr = (ul[0] + self.subs_shape[0], ul[1] + self.subs_shape[1])
+        ll = (ul[0] + self.subs_shape[0], ul[1])
+
+        # real world coords (note reversing (y, x) to (x, y)
+        ul_xy_map = ul[::-1] * self.geobox.transform
+        ur_xy_map = ur[::-1] * self.geobox.transform
+        lr_xy_map = lr[::-1] * self.geobox.transform
+        ll_xy_map = ll[::-1] * self.geobox.transform
+
+        # read subset
+        data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
+
+        count = 
+        self.assertTrue(data.sum() == count)
 
 if __name__ == '__main__':
     unittest.main()

--- a/wagl/data.py
+++ b/wagl/data.py
@@ -295,6 +295,10 @@ def read_subset(fname, ul_xy, ur_xy, lr_xy, ll_xy, edge_buffer=0, bands=1):
     """
     Return a 2D or 3D NumPy array subsetted to the given bounding
     extents.
+    The function will allow a user to ask for a region outside of the
+    requested domain. Those elements that fall outside of the
+    requested domain will be populated with the datasets' fillvalue
+    or 0 if the fillvalue is None.
 
     :param fname:
         A string containing the full file pathname to an image on

--- a/wagl/data.py
+++ b/wagl/data.py
@@ -383,7 +383,7 @@ def read_subset(fname, ul_xy, ur_xy, lr_xy, ll_xy, edge_buffer=0, bands=1):
     img_lr_x, img_lr_y = [int(v) for v in inv * lr_xy]
     img_ll_x, img_ll_y = [int(v) for v in inv * ll_xy]
 
-    # Calculate the min and max array extents
+    # Calculate the min and max array extents including edge_buffer
     xstart = min(img_ul_x, img_ll_x) - edge_buffer
     ystart = min(img_ul_y, img_ur_y) - edge_buffer
     xend = max(img_ur_x, img_lr_x) + edge_buffer
@@ -404,14 +404,19 @@ def read_subset(fname, ul_xy, ur_xy, lr_xy, ll_xy, edge_buffer=0, bands=1):
     source_ys = max(0, ystart)
     source_xe = min(cols, xend)
     source_ye = min(rows, yend)
-    intersect_shape = (source_ye - source_ys, source_xe - source_xs)
+
+    # source indices/slice
     source_idx = np.s_[source_ys:source_ye, source_xs:source_xe]
 
-    # destination index coords
+    # destination origin/start index (UL) coords -> abs(min(0, ul))
     dest_xs = abs(min(0, xstart))
     dest_ys = abs(min(0, ystart))
-    dest_xe = min(dims[1], intersect_shape[1])
-    dest_ye = min(dims[0], intersect_shape[0])
+
+    # destination end (LR) -> (source_end - source_start) + dest_start
+    dest_xe = (source_xe - source_xs) + dest_xs
+    dest_ye = (source_ye - source_ys) + dest_ys
+
+    # destination indices/slice
     dest_idx = np.s_[dest_ys:dest_ye, dest_xs:dest_xe]
 
     if isinstance(fname, h5py.Dataset):


### PR DESCRIPTION
I didn't correctly account for the array offset, leading to certain edge cases failing.

Now includes tests for 9 different intersection cases.  Doesn't include a complete out of bounds case.  I'm a bit indifferent to that case.  To truly support that I think the function needs to be enhanced in order to support returning only the intersected bounds, with a keyword allowing an array with a fillvalue to be populated.