### PR TITLE
Cleaner metadata structure

### DIFF
--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -12,7 +12,8 @@ from wagl.constants import DatasetName, GroupName
 from wagl.margins import pixel_buffer
 from wagl.geobox import GriddedGeoBox
 from wagl.data import reproject_array_to_array, read_subset
-from wagl.hdf5 import H5CompressionFilter, attach_image_attributes
+from wagl.hdf5 import H5CompressionFilter, attach_image_attributes, VLEN_STRING
+from wagl.metadata import current_h5_metadata
 
 
 def filter_dsm(array):
@@ -126,6 +127,9 @@ def get_dsm(acquisition, pathname, buffer_distance=8000, out_group=None,
         subs, subs_geobox = read_subset(dsm_ds, ul_xy, ur_xy, lr_xy, ll_xy,
                                         edge_buffer=1)
 
+        # ancillary metadata tracking
+        metadata = current_h5_metadata(dsm_fid, dataset_path=dname)
+
     # Retrive the DSM data
     dsm_data = reproject_array_to_array(subs, subs_geobox, dem_geobox,
                                         resampling=Resampling.bilinear)
@@ -174,6 +178,7 @@ def get_dsm(acquisition, pathname, buffer_distance=8000, out_group=None,
     desc = ("A subset of a Digital Surface Model smoothed with a gaussian "
             "kernel.")
     attrs['description'] = desc
+    attrs['id'] = numpy.array([metadata['id']], VLEN_STRING)
     attach_image_attributes(out_sm_dset, attrs)
 
     if out_group is None:

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -211,7 +211,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                 dname = fmt.format(band_name=bn, parameter=param.value)
                 dset = fid[dname]
                 ids.extend(dset.attrs['id'])
-                tier.append(BrdfTier[dset['tier']].value)
+                tier.append(BrdfTier[dset.attrs['tier']].value)
                 alpha_key = param.value.lower().replace('-', '_')
                 bn_key = bn.lower().replace('-', '_')
                 alphas[alpha_key][bn_key] = dset[()]

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function
 from datetime import datetime as dtime, timezone as dtz
 import os
 from os.path import dirname
+from posixpath import join as ppjoin
 import socket
 import uuid
 import numpy
@@ -19,7 +20,7 @@ import h5py
 import wagl
 from wagl.constants import (
     BrdfDirectionalParameters, DatasetName, POINT_FMT, GroupName,
-    BandType, Workflow
+    BandType, Workflow, BrdfTier
 )
 from wagl.hdf5 import write_scalar, read_h5_table, read_scalar
 
@@ -194,7 +195,12 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         """
         Load the ancillary data retrieved during the workflow.
         """
-        result = {}
+        ids = []
+        tier = []
+        alphas = {
+            'alpha_1': {},
+            'alpha_2': {},
+        }
         for acq in acquisitions:
             if acq.band_type == BandType.THERMAL:
                 continue
@@ -204,9 +210,24 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                 fmt = DatasetName.BRDF_FMT.value
                 dname = fmt.format(band_name=bn, parameter=param.value)
                 dset = fid[dname]
-                key = dname.lower().replace('-', '_')
-                result[key] = {k: v for k, v in dset.attrs.items()}
-                result[key]['value'] = dset[()]
+                ids.extend(dset['id'])
+                tier.append(BrdfTier[dset['tier']].value)
+                alpha_key = param.value.lower().replace('-', '_')
+                bn_key = bn.lower().replace('-', '_')
+                alphas[alpha_key][bn_key] = dset[()]
+
+        # unique listing of brdf ids
+        ids = numpy.unique(numpy.array(ids)).tolist()
+
+        # a single tier level will dictate the metadata entry
+        tier = BrdfTier(numpy.max(tier)).name
+
+        result = {
+            'id': ids,
+            'tier': tier,
+            'alpha_1': alphas['alpha_1'],
+            'alpha_2': alphas['alpha_2'],
+        }
 
         return result
 
@@ -231,6 +252,37 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         result.update(extract_ancillary_metadata(level1_path))
         return result
 
+    def remove_fields(data):
+        fields = ['CLASS', 'VERSION', 'query_date', 'data_source']
+        for field in fields:
+            data.pop(field, None)
+        return data
+
+    def elevation_provenance(anc_grp):
+        ids = []
+
+        # low resolution source
+        dname = DatasetName.ELEVATION.value
+        dset = anc_grp[dname]
+        ids.extend(dset['id'])
+
+        # high resolution source (res group is adjacent to ancillary group)
+        parent_group = anc_grp.parent
+        for res_group in res_group_bands:
+            dname = ppjoin(res_group,
+                           GroupName.ELEVATION_GROUP.name,
+                           DatasetName.DSM_SMOOTHED)
+            dset = parent_group[dname]
+            ids.extend(dset['id'])
+
+        # unique listing of ids
+        ids = numpy.unique(numpy.array(ids)).tolist()
+        md = {
+            'id': ids,
+        }
+
+        return md
+
     def ancillary(fid):
         # load the ancillary and remove fields not of use to ODC
         # retrieve the averaged ancillary if available
@@ -239,13 +291,14 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
             anc_grp = fid
 
         dname = DatasetName.AEROSOL.value
-        aerosol_data = read_scalar(anc_grp, dname)
+        aerosol_data = remove_fields(read_scalar(anc_grp, dname))
         dname = DatasetName.WATER_VAPOUR.value
-        water_vapour_data = read_scalar(anc_grp, dname)
+        water_vapour_data = remove_fields(read_scalar(anc_grp, dname))
         dname = DatasetName.OZONE.value
-        ozone_data = read_scalar(anc_grp, dname)
-        dname = DatasetName.ELEVATION.value
-        elevation_data = read_scalar(anc_grp, dname)
+        ozone_data = remove_fields(read_scalar(anc_grp, dname))
+
+        # currently have multiple sources of elevation data
+        elevation_data = elevation_provenance(anc_grp)
 
         result = {'aerosol': aerosol_data,
                   'water_vapour': water_vapour_data,
@@ -258,9 +311,6 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         if nbar:
             for grp_name in res_group_bands:
                 grp_ancillary = load_nbar_ancillary(res_group_bands[grp_name], fid)
-                for item in grp_ancillary:
-                    for remove in ['CLASS', 'VERSION', 'query_date', 'data_source']:
-                        grp_ancillary[item].pop(remove, None)
                 result.update(grp_ancillary)
 
         return result

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function
 from datetime import datetime as dtime, timezone as dtz
 import os
 from os.path import dirname
+from posixpath import join as ppjoin
 import socket
 import uuid
 import numpy
@@ -19,7 +20,7 @@ import h5py
 import wagl
 from wagl.constants import (
     BrdfDirectionalParameters, DatasetName, POINT_FMT, GroupName,
-    BandType, Workflow
+    BandType, Workflow, BrdfTier
 )
 from wagl.hdf5 import write_scalar, read_h5_table, read_scalar
 
@@ -194,7 +195,12 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         """
         Load the ancillary data retrieved during the workflow.
         """
-        result = {}
+        ids = []
+        tier = []
+        alphas = {
+            'alpha_1': {},
+            'alpha_2': {},
+        }
         for acq in acquisitions:
             if acq.band_type == BandType.THERMAL:
                 continue
@@ -204,9 +210,24 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                 fmt = DatasetName.BRDF_FMT.value
                 dname = fmt.format(band_name=bn, parameter=param.value)
                 dset = fid[dname]
-                key = dname.lower().replace('-', '_')
-                result[key] = {k: v for k, v in dset.attrs.items()}
-                result[key]['value'] = dset[()]
+                ids.extend(dset['id'])
+                tier.append(BrdfTier[dset['tier']].value)
+                alpha_key = param.value.lower().replace('-', '_')
+                bn_key = bn.lower().replace('-', '_')
+                alphas[alpha_key][bn_key] = dset[()]
+
+        # unique listing of brdf ids
+        ids = numpy.unique(numpy.array(ids)).tolist()
+
+        # a single tier level will dictate the metadata entry
+        tier = BrdfTier(numpy.max(tier)).name
+
+        result = {
+            'id': ids,
+            'tier': tier,
+            'alpha_1': alphas['alpha_1'],
+            'alpha_2': alphas['alpha_2'],
+        }
 
         return result
 
@@ -238,6 +259,37 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
 
         return result
 
+    def remove_fields(data):
+        fields = ['CLASS', 'VERSION', 'query_date', 'data_source']
+        for field in fields:
+            data.pop(field, None)
+        return data
+
+    def elevation_provenance(anc_grp):
+        ids = []
+
+        # low resolution source
+        dname = DatasetName.ELEVATION.value
+        dset = anc_grp[dname]
+        ids.extend(dset['id'])
+
+        # high resolution source (res group is adjacent to ancillary group)
+        parent_group = anc_grp.parent
+        for res_group in res_group_bands:
+            dname = ppjoin(res_group,
+                           GroupName.ELEVATION_GROUP.name,
+                           DatasetName.DSM_SMOOTHED)
+            dset = parent_group[dname]
+            ids.extend(dset['id'])
+
+        # unique listing of ids
+        ids = numpy.unique(numpy.array(ids)).tolist()
+        md = {
+            'id': ids,
+        }
+
+        return md
+
     def ancillary(fid):
         # load the ancillary and remove fields not of use to ODC
         # retrieve the averaged ancillary if available
@@ -246,13 +298,14 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
             anc_grp = fid
 
         dname = DatasetName.AEROSOL.value
-        aerosol_data = read_scalar(anc_grp, dname)
+        aerosol_data = remove_fields(read_scalar(anc_grp, dname))
         dname = DatasetName.WATER_VAPOUR.value
-        water_vapour_data = read_scalar(anc_grp, dname)
+        water_vapour_data = remove_fields(read_scalar(anc_grp, dname))
         dname = DatasetName.OZONE.value
-        ozone_data = read_scalar(anc_grp, dname)
-        dname = DatasetName.ELEVATION.value
-        elevation_data = read_scalar(anc_grp, dname)
+        ozone_data = remove_fields(read_scalar(anc_grp, dname))
+
+        # currently have multiple sources of elevation data
+        elevation_data = elevation_provenance(anc_grp)
 
         result = {'aerosol': aerosol_data,
                   'water_vapour': water_vapour_data,
@@ -265,9 +318,6 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         if nbar:
             for grp_name in res_group_bands:
                 grp_ancillary = load_nbar_ancillary(res_group_bands[grp_name], fid)
-                for item in grp_ancillary:
-                    for remove in ['CLASS', 'VERSION', 'query_date', 'data_source']:
-                        grp_ancillary[item].pop(remove, None)
                 result.update(grp_ancillary)
 
         return result

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -210,7 +210,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                 fmt = DatasetName.BRDF_FMT.value
                 dname = fmt.format(band_name=bn, parameter=param.value)
                 dset = fid[dname]
-                ids.extend(dset['id'])
+                ids.extend(dset.attrs['id'])
                 tier.append(BrdfTier[dset['tier']].value)
                 alpha_key = param.value.lower().replace('-', '_')
                 bn_key = bn.lower().replace('-', '_')
@@ -264,7 +264,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         # low resolution source
         dname = DatasetName.ELEVATION.value
         dset = anc_grp[dname]
-        ids.extend(dset['id'])
+        ids.extend(dset.attrs['id'])
 
         # high resolution source (res group is adjacent to ancillary group)
         parent_group = anc_grp.parent
@@ -273,7 +273,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
                            GroupName.ELEVATION_GROUP.name,
                            DatasetName.DSM_SMOOTHED)
             dset = parent_group[dname]
-            ids.extend(dset['id'])
+            ids.extend(dset.attrs['id'])
 
         # unique listing of ids
         ids = numpy.unique(numpy.array(ids)).tolist()

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -271,7 +271,7 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         for res_group in res_group_bands:
             dname = ppjoin(res_group,
                            GroupName.ELEVATION_GROUP.name,
-                           DatasetName.DSM_SMOOTHED)
+                           DatasetName.DSM_SMOOTHED.name)
             dset = parent_group[dname]
             ids.extend(dset.attrs['id'])
 

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -270,8 +270,8 @@ def create_ard_yaml(res_group_bands, ancillary_group, out_group, parameters, wor
         parent_group = anc_grp.parent
         for res_group in res_group_bands:
             dname = ppjoin(res_group,
-                           GroupName.ELEVATION_GROUP.name,
-                           DatasetName.DSM_SMOOTHED.name)
+                           GroupName.ELEVATION_GROUP.value,
+                           DatasetName.DSM_SMOOTHED.value)
             dset = parent_group[dname]
             ids.extend(dset.attrs['id'])
 


### PR DESCRIPTION
WIP

@uchchwhash Can you patch up the piece I'm missing for the cleaner BRDF metadata.  The alpha1 and alpha2 fields need to be under the 'brdf' field, and the 'id' field sitting on its own needs to be incorporated into the 'brdf' section.  Somehow I missed it, but I need to get onto other work.
Also, this change does break the multifile workflow, but that is ok as we need to restructure that workflow anyway.