### PR TITLE
Force the acquisition_datetime to be UTC, but remove the timezone. Th…

### DIFF
--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -147,6 +147,10 @@ class Landsat5Scene1AcquisitionTest(unittest.TestCase):
                                        window=((40, 41), (40, 41)))
         self.assertAlmostEqual(result[0, 0], 293.76944042)
 
+    def test_tzinfo(self):
+        for acq in self.acqs:
+            self.assertTrue(acq.acquisition_datetime, None)
+
 
 class Landsat7Mtl1AcquisitionTest(unittest.TestCase):
 
@@ -231,6 +235,10 @@ class Landsat7Mtl1AcquisitionTest(unittest.TestCase):
                                        window=((41, 42), (41, 42)))
         self.assertAlmostEqual(result[0, 0], 293.990413299)
 
+    def test_tzinfo(self):
+        for acq in self.acqs:
+            self.assertTrue(acq.acquisition_datetime, None)
+
 
 class Landsat7PanAcquisitionTest(unittest.TestCase):
 
@@ -243,6 +251,10 @@ class Landsat7PanAcquisitionTest(unittest.TestCase):
 
     def test_band_type(self):
         self.assertEqual(self.acqs[0].band_type, BandType.REFLECTIVE)
+
+    def test_tzinfo(self):
+        for acq in self.acqs:
+            self.assertTrue(acq.acquisition_datetime, None)
 
 
 class Landsat8Mtl1AcquisitionTest(unittest.TestCase):
@@ -330,6 +342,10 @@ class Landsat8Mtl1AcquisitionTest(unittest.TestCase):
                                        window=((41, 42), (41, 42)))
         self.assertAlmostEqual(result[0, 0], 298.049253923)
 
+    def test_tzinfo(self):
+        for acq in self.acqs:
+            self.assertTrue(acq.acquisition_datetime, None)
+
 
 class Landsat8PanAcquisitionTest(unittest.TestCase):
 
@@ -342,6 +358,10 @@ class Landsat8PanAcquisitionTest(unittest.TestCase):
 
     def test_band_type(self):
         self.assertEqual(self.acqs[0].band_type, BandType.REFLECTIVE)
+
+    def test_tzinfo(self):
+        for acq in self.acqs:
+            self.assertTrue(acq.acquisition_datetime, None)
 
 
 if __name__ == '__main__':

--- a/tests/test_acquisition_sentinel.py
+++ b/tests/test_acquisition_sentinel.py
@@ -54,8 +54,7 @@ class Sentinel2AScene1AcquisitionTest(unittest.TestCase):
             self.assertEqual(acq.band_type, BandType.REFLECTIVE)
 
     def test_acquisition_datetime(self):
-        test_date = datetime.datetime(2017, 12, 7, 0, 22, 52, 127000, 
-                                      datetime.timezone.utc)
+        test_date = datetime.datetime(2017, 12, 7, 0, 22, 52, 127000)
         for acq in self.container.get_all_acquisitions():
            self.assertEqual(acq.acquisition_datetime, test_date)
 
@@ -79,6 +78,10 @@ class Sentinel2AScene1AcquisitionTest(unittest.TestCase):
     def test_read(self):
         self.assertEqual(self.acq.data()[70, 30], 1083)
 
+    def test_tzinfo(self):
+        for acq in self.container.get_all_acquisitions():
+            self.assertTrue(acq.acquisition_datetime, None)
+
 
 class Sentinel2BScene1AcquisitionTest(unittest.TestCase):
     def setUp(self):
@@ -91,8 +94,7 @@ class Sentinel2BScene1AcquisitionTest(unittest.TestCase):
             self.assertEqual(acq.band_type, BandType.REFLECTIVE)
 
     def test_acquisition_datetime(self):
-        test_date = datetime.datetime(2017, 7, 19, 0, 2, 18, 457000,
-                                      datetime.timezone.utc)
+        test_date = datetime.datetime(2017, 7, 19, 0, 2, 18, 457000)
         for acq in self.container.get_all_acquisitions():
            self.assertEqual(acq.acquisition_datetime, test_date)
 
@@ -115,3 +117,7 @@ class Sentinel2BScene1AcquisitionTest(unittest.TestCase):
                          'sentinel2b_all.flt')
     def test_read(self):
         self.assertEqual(self.acq.data()[100, 100], 2)
+
+    def test_tzinfo(self):
+        for acq in self.container.get_all_acquisitions():
+            self.assertTrue(acq.acquisition_datetime, None)

--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -1,6 +1,7 @@
 """
 Contains the base implementations for the acquisition and AcquisitionsContainer objects
 """
+import dateutil
 from os.path import join as pjoin
 from functools import total_ordering
 from pkg_resources import resource_filename
@@ -242,7 +243,7 @@ class Acquisition:
                  band_id='1', metadata=None):
         self._pathname = pathname
         self._uri = uri
-        self._acquisition_datetime = acquisition_datetime
+        self._acquisition_datetime = acquisition_datetime.astimezone(dateutil.tz.UTC).replace(tzinfo=None)
         self._band_name = band_name
         self._band_id = band_id
 


### PR DESCRIPTION
…is was to get ensure consistency amongst all supported sensors, and with pandas Timestamps which did not neccessarily have timezone information.

Reaons why; Sentinel-2 acquisition returned a datetime object with a timezone whereas Landsat acquisitions didn't.  Pandas failed to compare against datetime objects that contained a timezone.