### PR TITLE
Remove the force datetime to utc as for non-timezone aware datetime o…

### DIFF
--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -243,7 +243,7 @@ class Acquisition:
                  band_id='1', metadata=None):
         self._pathname = pathname
         self._uri = uri
-        self._acquisition_datetime = acquisition_datetime.astimezone(dateutil.tz.UTC).replace(tzinfo=None)
+        self._acquisition_datetime = acquisition_datetime.replace(tzinfo=None)
         self._band_name = band_name
         self._band_id = band_id
 

--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -28,7 +28,7 @@ def set_utc(acq_dt):
     """
     if acq_dt.tzinfo is None:
         # assume UTC
-        return acq_dt.replace(dateutil.tz.UTC)
+        return acq_dt.replace(tzinfo=dateutil.tz.UTC)
     else:
         return acq_dt.astimezone(dateutil.tz.UTC)
 

--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -243,7 +243,11 @@ class Acquisition:
                  band_id='1', metadata=None):
         self._pathname = pathname
         self._uri = uri
+
+        # strip the datetime as it can play havoc with other libs
+        # this also assumes that the datetime is already in UTC
         self._acquisition_datetime = acquisition_datetime.replace(tzinfo=None)
+
         self._band_name = band_name
         self._band_id = band_id
 

--- a/wagl/acquisition/base.py
+++ b/wagl/acquisition/base.py
@@ -14,6 +14,25 @@ from ..modtran import read_spectral_response
 from ..tiling import generate_tiles
 from ..constants import BandType
 
+
+def set_utc(acq_dt):
+    """
+    Check the timezone and convert to UTC if either no timezone
+    exists, or if the acquisition datetime is not in UTC.
+
+    :param acq_dt:
+        The acquisition datetime as a Python datetime object.
+
+    :return:
+        The acquisition datetime set to UTC.
+    """
+    if acq_dt.tzinfo is None:
+        # assume UTC
+        return acq_dt.replace(dateutil.tz.UTC)
+    else:
+        return acq_dt.astimezone(dateutil.tz.UTC)
+
+
 class AcquisitionsContainer:
 
     """
@@ -244,9 +263,8 @@ class Acquisition:
         self._pathname = pathname
         self._uri = uri
 
-        # strip the datetime as it can play havoc with other libs
-        # this also assumes that the datetime is already in UTC
-        self._acquisition_datetime = acquisition_datetime.replace(tzinfo=None)
+        # strip the timezone as it been playing havoc with other libs
+        self._acquisition_datetime = set_utc(acquisition_datetime).replace(tzinfo=None)
 
         self._band_name = band_name
         self._band_id = band_id


### PR DESCRIPTION
…bjects it will assume local then convert to UTC. This is an issue if the time is already UTC. Instead we'll now simply strip any timezone aware datetime objects.