### PR TITLE
Consolidate logging

### DIFF
--- a/configs/logging.cfg
+++ b/configs/logging.cfg
@@ -1,8 +1,8 @@
 [loggers]
-keys=root, luigiStatus, waglError, waglStatus, rasterio
+keys=root, luigiStatus, taskStatus, waglStatus, rasterio
 
 [handlers]
-keys=consoleHandler, fileHandler, errfileHandler, waglfileHandler
+keys=consoleHandler, fileHandler, taskfileHandler, waglfileHandler
 
 [formatters]
 keys=simpleFormatter, JSONL
@@ -17,10 +17,10 @@ handlers=fileHandler
 qualname=luigi-interface
 propagate=0
 
-[logger_waglError]
-level=ERROR
-handlers=errfileHandler
-qualname=error
+[logger_taskStatus]
+level=INFO
+handlers=taskfileHandler
+qualname=task
 propagate=0
 
 [logger_waglStatus]
@@ -47,17 +47,17 @@ level=INFO
 formatter=simpleFormatter
 args=('luigi-interface.log',)
 
-[handler_errfileHandler]
+[handler_taskfileHandler]
 class=FileHandler
-level=ERROR
+level=INFO
 formatter=JSONL
-args=('errors.log',)
+args=('task-log.jsonl',)
 
 [handler_waglfileHandler]
 class=FileHandler
 level=INFO
 formatter=JSONL
-args=('status.log',)
+args=('status-log.jsonl',)
 
 [formatter_simpleFormatter]
 format=%(asctime)s: %(levelname)s: %(message)s

--- a/wagl/logs.py
+++ b/wagl/logs.py
@@ -2,7 +2,7 @@
 Logging configuration for wagl logs
 
 Defines structured logging for:
-    * Errors            -- qualname error
+    * Task message      -- qualname task
     * Status messages   -- qualname status
     * Luigi interface   -- qualname luigi-interface
 """
@@ -37,7 +37,8 @@ class FormatJSONL(logging.Formatter):
         """ Disables printing separate stack traces """
         return
 
-ERROR_LOGGER = get_wrapped_logger('error', stack_info=True)
+
+TASK_LOGGER = get_wrapped_logger('task', stack_info=True)
 STATUS_LOGGER = get_wrapped_logger('status')
 
 INTERFACE_LOGGER = logging.getLogger('luigi-interface')

--- a/wagl/logs.py
+++ b/wagl/logs.py
@@ -38,7 +38,7 @@ class FormatJSONL(logging.Formatter):
         return
 
 
-TASK_LOGGER = get_wrapped_logger('task', stack_info=True)
+TASK_LOGGER = get_wrapped_logger('task')
 STATUS_LOGGER = get_wrapped_logger('status')
 
 INTERFACE_LOGGER = logging.getLogger('luigi-interface')

--- a/wagl/multifile_workflow.py
+++ b/wagl/multifile_workflow.py
@@ -53,17 +53,27 @@ from wagl.interpolation import _interpolate, link_interpolated_data
 from wagl.temperature import _surface_brightness_temperature
 from wagl.pq import can_pq, _run_pq
 from wagl.hdf5 import create_external_link, H5CompressionFilter
-from wagl.logs import ERROR_LOGGER
+from wagl.logs import TASK_LOGGER
 
 
 @luigi.Task.event_handler(luigi.Event.FAILURE)
 def on_failure(task, exception):
     """Capture any Task Failure here."""
-    ERROR_LOGGER.error(task=task.get_task_family(),
-                       params=task.to_str_params(),
-                       level1=getattr(task, 'level1', ''),
-                       exception=exception.__str__(),
-                       traceback=traceback.format_exc().splitlines())
+    TASK_LOGGER.exception(task=task.get_task_family(),
+                          params=task.to_str_params(),
+                          level1=getattr(task, 'level1', ''),
+                          status='failure',
+                          exception=exception.__str__(),
+                          traceback=traceback.format_exc().splitlines())
+
+
+@luigi.Task.event_handler(luigi.Event.SUCCESS)
+def on_success(task):
+    """Capture any Task Success here."""
+    TASK_LOGGER.info(task=task.get_task_family(),
+                     params=task.to_str_params(),
+                     level1=getattr(task, 'level1', ''),
+                     status='success')
 
 
 class WorkRoot(luigi.Task):

--- a/wagl/multifile_workflow.py
+++ b/wagl/multifile_workflow.py
@@ -62,6 +62,7 @@ def on_failure(task, exception):
     TASK_LOGGER.exception(task=task.get_task_family(),
                           params=task.to_str_params(),
                           level1=getattr(task, 'level1', ''),
+                          stack_info=True,
                           status='failure',
                           exception=exception.__str__(),
                           traceback=traceback.format_exc().splitlines())

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -41,6 +41,7 @@ def on_failure(task, exception):
     TASK_LOGGER.exception(task=task.get_task_family(),
                           params=task.to_str_params(),
                           level1=getattr(task, 'level1', ''),
+                          stack_info=True,
                           status='failure',
                           exception=exception.__str__(),
                           traceback=traceback.format_exc().splitlines())

--- a/wagl/singlefile_workflow.py
+++ b/wagl/singlefile_workflow.py
@@ -32,17 +32,27 @@ from wagl.constants import Workflow, Method
 from wagl.hdf5 import H5CompressionFilter
 from wagl.standardise import card4l
 
-from wagl.logs import ERROR_LOGGER
+from wagl.logs import TASK_LOGGER
 
 
 @luigi.Task.event_handler(luigi.Event.FAILURE)
 def on_failure(task, exception):
     """Capture any Task Failure here."""
-    ERROR_LOGGER.exception(task=task.get_task_family(),
-                           params=task.to_str_params(),
-                           level1=getattr(task, 'level1', ''),
-                           exception=exception.__str__(),
-                           traceback=traceback.format_exc().splitlines())
+    TASK_LOGGER.exception(task=task.get_task_family(),
+                          params=task.to_str_params(),
+                          level1=getattr(task, 'level1', ''),
+                          status='failure',
+                          exception=exception.__str__(),
+                          traceback=traceback.format_exc().splitlines())
+
+
+@luigi.Task.event_handler(luigi.Event.SUCCESS)
+def on_success(task):
+    """Capture any Task Success here."""
+    TASK_LOGGER.info(task=task.get_task_family(),
+                     params=task.to_str_params(),
+                     level1=getattr(task, 'level1', ''),
+                     status='success')
 
 
 class DataStandardisation(luigi.Task):


### PR DESCRIPTION
Changing the logging structure so that we output a single log for task events that result in either SUCCESS or FAILURE, rather than only those that return FAILURE.