### PR TITLE
GDAL3 update

### DIFF
--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -251,7 +251,7 @@ class TestGriddedGeoBox(unittest.TestCase):
 
     def test_ggb_transform_from_h5_dataset(self):
         img, geobox = ut.create_test_image()
-        with h5py.File('tmp.h5', driver='core', backing_store=False) as fid:
+        with h5py.File('tmp.h5', 'w', driver='core', backing_store=False) as fid:
             ds = fid.create_dataset('test', data=img)
             ds.attrs['geotransform'] = geobox.transform.to_gdal()
             ds.attrs['crs_wkt'] = geobox.crs.ExportToWkt()
@@ -261,7 +261,7 @@ class TestGriddedGeoBox(unittest.TestCase):
 
     def test_ggb_crs_from_h5_dataset(self):
         img, geobox = ut.create_test_image()
-        with h5py.File('tmp.h5', driver='core', backing_store=False) as fid:
+        with h5py.File('tmp.h5', 'w', driver='core', backing_store=False) as fid:
             ds = fid.create_dataset('test', data=img)
             ds.attrs['geotransform'] = geobox.transform.to_gdal()
             ds.attrs['crs_wkt'] = geobox.crs.ExportToWkt()
@@ -272,7 +272,7 @@ class TestGriddedGeoBox(unittest.TestCase):
 
     def test_ggb_shape_from_h5_dataset(self):
         img, geobox = ut.create_test_image()
-        with h5py.File('tmp.h5', driver='core', backing_store=False) as fid:
+        with h5py.File('tmp.h5', 'w', driver='core', backing_store=False) as fid:
             ds = fid.create_dataset('test', data=img)
             ds.attrs['geotransform'] = geobox.transform.to_gdal()
             ds.attrs['crs_wkt'] = geobox.crs.ExportToWkt()

--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -338,6 +338,56 @@ class TestGriddedGeoBox(unittest.TestCase):
 
         self.assertIsNone(npt.assert_almost_equal(truth, exts, decimal=7))
 
+    def test_lonlat_to_utm(self):
+        """
+        Test that coordinates in one CRS are correctly transformed
+        from lonlat into utm
+        This came about with GDAL3 and Proj6, where the native axis
+        mapping of a CRS is respected, meaning that an x,y input and
+        output is dependent on the CRS axis.
+        We'll instead enforce the x,y axis mapping strategy.
+        """
+        shape = (3, 2)
+        origin = (150.0, -34.0)
+        ggb = GriddedGeoBox(shape, origin)
+
+        lon = 148.862561
+        lat = -35.123064
+
+        to_crs = osr.SpatialReference()
+        to_crs.ImportFromEPSG(32755)
+
+        easting, northing = ggb.transform_coordinates((lon, lat), to_crs)
+
+        self.assertAlmostEqual(easting, 669717.105361586)
+        self.assertAlmostEqual(northing, 6111722.038508673)
+
+    def test_utm_to_lonlat(self):
+        """
+        Test that coordinates in one CRS are correctly transformed
+        from utm into lonlat
+        This came about with GDAL3 and Proj6, where the native axis
+        mapping of a CRS is respected, meaning that an x,y input and
+        output is dependent on the CRS axis.
+        We'll instead enforce the x,y axis mapping strategy.
+        """
+        shape = (3, 2)
+        origin = (669700, 6111700)
+        ggb = GriddedGeoBox(shape, origin, crs='EPSG:32755')
+
+        lon = 148.862561
+        lat = -35.123064
+        easting = 669717.105361586
+        northing = 6111722.038508673
+
+        to_crs = osr.SpatialReference()
+        to_crs.ImportFromEPSG(4326)
+
+        lon, lat = ggb.transform_coordinates((easting, northing), to_crs)
+
+        self.assertAlmostEqual(lon, 148.862561)
+        self.assertAlmostEqual(lat, -35.123064)
+
     # def test_pixelscale_metres(self):
     #     scale = 0.00025
     #     shape = (4000, 4000)

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -188,7 +188,7 @@ class HDF5Test(unittest.TestCase):
         """
         data = self.scalar_data
         fname = 'test_write_scalar.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             self.assertIsNone(hdf5.write_scalar(data, 'scalar', fid))
 
     def test_scalar_attributes(self):
@@ -205,7 +205,7 @@ class HDF5Test(unittest.TestCase):
             data[k] = v
 
         fname = 'test_scalar_dataset.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_scalar(data['value'], 'test-scalar', fid, attrs=attrs)
 
             self.assertDictEqual(hdf5.read_scalar(fid, 'test-scalar'), data)
@@ -218,7 +218,7 @@ class HDF5Test(unittest.TestCase):
         attrs = {'timestamp': datetime.datetime.now()}
 
         fname = 'test_datetime_attrs.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_scalar(self.scalar_data, 'scalar', fid, attrs=attrs)
 
             data = hdf5.read_scalar(fid, 'scalar')
@@ -231,7 +231,7 @@ class HDF5Test(unittest.TestCase):
         attrs = {'alpha': 1, 'beta': 2}
 
         fname = 'test_attach_attributes.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             dset = fid.create_dataset('data', data=self.image_data)
             hdf5.attach_attributes(dset, attrs)
             test = {k: v for k, v in dset.attrs.items()}
@@ -243,7 +243,7 @@ class HDF5Test(unittest.TestCase):
         """
         data = self.image_data
         fname = 'test_write_h5_image.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             self.assertIsNone(hdf5.write_h5_image(data, 'image', fid))
 
     def test_write_h5_table(self):
@@ -252,7 +252,7 @@ class HDF5Test(unittest.TestCase):
         """
         data = self.table_data
         fname = 'test_write_h5_table.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             self.assertIsNone(hdf5.write_h5_table(data, 'table', fid))
 
     def test_attach_image_attributes(self):
@@ -264,7 +264,7 @@ class HDF5Test(unittest.TestCase):
                  'DISPLAY_ORIGIN': 'UL'}
 
         fname = 'test_attach_image_attributes.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             dset = fid.create_dataset('data', data=self.image_data)
             hdf5.attach_image_attributes(dset, attrs)
             test = {k: v for k, v in dset.attrs.items()}
@@ -279,7 +279,7 @@ class HDF5Test(unittest.TestCase):
                  'DISPLAY_ORIGIN': 'UL'}
 
         fname = 'test_write_h5_image_attributes.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_h5_image(self.image_data, 'image', fid)
             test = {k: v for k, v in fid['image'].attrs.items()}
 
@@ -295,7 +295,7 @@ class HDF5Test(unittest.TestCase):
         minmax = numpy.array([self.image_data.min(), self.image_data.max()])
 
         fname = 'test_write_h5_image_minmax.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_h5_image(self.image_data, 'image', fid)
 
             test = fid['image'].attrs['IMAGE_MINMAXRANGE']
@@ -315,7 +315,7 @@ class HDF5Test(unittest.TestCase):
         minmax = numpy.array([self.image_data.min(), self.image_data.max()])
 
         fname = 'test_write_h5_multi.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_h5_image(dataset, 'image', fid)
 
             self.assertFalse('IMAGE_MINMAXRANGE' in fid['image'].attrs)
@@ -337,7 +337,7 @@ class HDF5Test(unittest.TestCase):
                  'FIELD_1_NAME': 'integer_data'}
 
         fname = 'test_attach_table_attributes.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             dset = fid.create_dataset('data', data=self.table_data)
             hdf5.attach_table_attributes(dset, attrs=attrs)
             test = {k: v for k, v in dset.attrs.items()}
@@ -349,7 +349,7 @@ class HDF5Test(unittest.TestCase):
         """
         df = pandas.DataFrame(self.table_data)
         fname = 'test_write_dataframe.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             self.assertIsNone(hdf5.write_dataframe(df, 'dataframe', fid))
 
     def test_dataframe_attributes(self):
@@ -373,7 +373,7 @@ class HDF5Test(unittest.TestCase):
         df = pandas.DataFrame(self.table_data)
 
         fname = 'test_dataframe_attributes.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_dataframe(df, 'dataframe', fid)
 
             test = {k: v for k, v in fid['dataframe'].attrs.items()}
@@ -391,7 +391,7 @@ class HDF5Test(unittest.TestCase):
         df['string_data'] = ['period {}'.format(i) for i in range(10)]
 
         fname = 'test_dataframe_roundtrip.h5'
-        with h5py.File(fname, **self.memory_kwargs) as fid:
+        with h5py.File(fname, 'w', **self.memory_kwargs) as fid:
             hdf5.write_dataframe(df, 'dataframe', fid)
             # Apply conversion to no timezone that occurs in serialisation to hdf5
             # Numpy is timezone naive; pandas has timezone support

--- a/tests/test_read_subset.py
+++ b/tests/test_read_subset.py
@@ -224,10 +224,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -257,10 +257,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -290,10 +290,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -321,10 +321,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -352,10 +352,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -383,10 +383,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -417,10 +417,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -451,10 +451,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -485,10 +485,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         data, gb = read_subset(self.ds, ul_xy_map, ur_xy_map, lr_xy_map, ll_xy_map)
@@ -515,10 +515,10 @@ class TestReadSubset(unittest.TestCase):
         ll = (ul[0] + self.subs_shape[0], ul[1])
 
         # real world coords (note reversing (y, x) to (x, y)
-        ul_xy_map = ul[::-1] * self.geobox.transform
-        ur_xy_map = ur[::-1] * self.geobox.transform
-        lr_xy_map = lr[::-1] * self.geobox.transform
-        ll_xy_map = ll[::-1] * self.geobox.transform
+        ul_xy_map = self.geobox.transform * ul[::-1]
+        ur_xy_map = self.geobox.transform * ur[::-1]
+        lr_xy_map = self.geobox.transform * lr[::-1]
+        ll_xy_map = self.geobox.transform * ll[::-1]
 
         # read subset
         with self.assertRaises(IndexError):

--- a/tests/test_read_subset.py
+++ b/tests/test_read_subset.py
@@ -19,7 +19,7 @@ class TestReadSubset(unittest.TestCase):
     img, geobox = ut.create_test_image((1200, 1500))
     img[:] = 1
 
-    fid = h5py.File('test-subset.h5', backing_store=False, driver='core')
+    fid = h5py.File('test-subset.h5', 'w', backing_store=False, driver='core')
     ds = fid.create_dataset('data', data=img)
     ds.attrs['geotransform'] = geobox.transform.to_gdal()
     ds.attrs['crs_wkt'] = geobox.crs.ExportToWkt()

--- a/wagl/ancillary.py
+++ b/wagl/ancillary.py
@@ -163,7 +163,7 @@ def collect_ancillary(container, satellite_solar_group, nbar_paths,
     """
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('ancillary.h5', driver='core', backing_store=False)
+        fid = h5py.File('ancillary.h5', 'w', driver='core', backing_store=False)
     else:
         fid = out_group
 
@@ -245,7 +245,7 @@ def collect_sbt_ancillary(acquisition, lonlats, ancillary_path,
     """
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('sbt-ancillary.h5', driver='core', backing_store=False)
+        fid = h5py.File('sbt-ancillary.h5', 'w', driver='core', backing_store=False)
     else:
         fid = out_group
 
@@ -402,7 +402,7 @@ def collect_nbar_ancillary(container, aerosol_dict=None,
     """
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('nbar-ancillary.h5', driver='core',
+        fid = h5py.File('nbar-ancillary.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/ancillary.py
+++ b/wagl/ancillary.py
@@ -697,7 +697,7 @@ def get_water_vapour(acquisition, water_vapour_dict, scale_factor=0.1,
         # get the index of the closest water vapour observation
         # which would be the maximum timedelta
         # as we're only dealing with negative timedelta's here
-        idx = result.argmax()
+        idx = result.idxmax()
         record = index.iloc[idx]
         dataset_name = record.dataset_name
 

--- a/wagl/dsm.py
+++ b/wagl/dsm.py
@@ -140,7 +140,7 @@ def get_dsm(acquisition, pathname, buffer_distance=8000, out_group=None,
     # Output the reprojected result
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('dsm-subset.h5', driver='core', backing_store=False)
+        fid = h5py.File('dsm-subset.h5', 'w', driver='core', backing_store=False)
     else:
         fid = out_group
 

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -218,6 +218,10 @@ class GriddedGeoBox:
             self.crs = osr.SpatialReference()
             if self.crs == self.crs.SetFromUserInput(crs):
                 raise ValueError("Invalid crs: %s" % (crs, ))
+
+        # enforce x,y axis ordering
+        self.crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+
         self.transform = Affine(self.pixelsize[0], 0, self.origin[0], 0,
                                 -self.pixelsize[1], self.origin[1])
         self.corner = self.transform * self.get_shape_xy()
@@ -357,6 +361,10 @@ class GriddedGeoBox:
             err = 'Err: to_crs is not an instance of osr.SpatialReference: {}'
             err = err.format(type(to_crs))
             raise TypeError(err)
+
+        # ensure we using the traditional x, y axis ordering
+        self.crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        to_crs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
         # Define the transform we are transforming to
         transform = osr.CoordinateTransformation(self.crs, to_crs)

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -335,7 +335,7 @@ class GriddedGeoBox:
         if to_map:
             if centre:
                 xy = tuple(v + 0.5 for v in xy)
-            x, y = xy * self.transform
+            x, y = self.transform * xy
         else:
             inv = ~self.transform
             x, y = [int(v) for v in inv * xy]
@@ -450,10 +450,10 @@ class GriddedGeoBox:
         left = (numpy.array([0] * row_ll_idx), row_ids[::-1])
 
         # convert to indices to geobox native map units
-        top_map = top * self.transform
-        right_map = right * self.transform
-        bottom_map = bottom * self.transform
-        left_map = left * self.transform
+        top_map = self.transform * top
+        right_map = self.transform * right
+        bottom_map = self.transform * bottom
+        left_map = self.transform * left
 
         # form a polygon
         coords = []

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -321,7 +321,7 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
         _dtype_name = idx_data.dtype.name
         if 'datetime64' in _dtype_name:
             # Pandas supports timezones but numpy does not; remove timezone
-            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
+            _dtype_name = re.sub(r'\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
         dtype_metadata['{}_dtype'.format(idx_name)] = _dtype_name
         if _dtype_name == 'object':
             dtype.append((idx_name, VLEN_STRING))
@@ -336,7 +336,7 @@ def write_dataframe(df, dset_name, group, compression=H5CompressionFilter.LZF,
         _dtype_name = val.name
         if 'datetime64' in _dtype_name:
             # Pandas supports timezones but numpy does not; remove timezone
-            _dtype_name = re.sub('\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
+            _dtype_name = re.sub(r'\[ns(?:,[^\]]+)?\]', '[ns]', _dtype_name)
         dtype_metadata['{}_dtype'.format(col_name)] = _dtype_name
         if _dtype_name == 'object':
             dtype.append((col_name, VLEN_STRING))

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -477,7 +477,7 @@ def create_external_link(fname, dataset_path, out_fname, new_dataset_path):
         A `str` containing the dataset path within `out_fname` that will
         link to `fname:dataset_path`.
     """
-    with h5py.File(out_fname) as fid:
+    with h5py.File(out_fname, 'a') as fid:
         fid[new_dataset_path] = h5py.ExternalLink(fname, dataset_path)
 
 

--- a/wagl/incident_exiting_angles.py
+++ b/wagl/incident_exiting_angles.py
@@ -96,7 +96,7 @@ def incident_angles(satellite_solar_group, slope_aspect_group, out_group=None,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('incident-angles.h5', driver='core',
+        fid = h5py.File('incident-angles.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -236,7 +236,7 @@ def exiting_angles(satellite_solar_group, slope_aspect_group, out_group=None,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('exiting-angles.h5', driver='core',
+        fid = h5py.File('exiting-angles.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -388,7 +388,7 @@ def relative_azimuth_slope(incident_angles_group, exiting_angles_group,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('relative-azimuth-angles.h5', driver='core',
+        fid = h5py.File('relative-azimuth-angles.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/interpolation.py
+++ b/wagl/interpolation.py
@@ -482,7 +482,7 @@ def interpolate(acq, coefficient, ancillary_group, satellite_solar_group,
 
     # setup the output file/group as needed
     if out_group is None:
-        fid = h5py.File('interpolated-coefficients.h5', driver='core',
+        fid = h5py.File('interpolated-coefficients.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/longitude_latitude_arrays.py
+++ b/wagl/longitude_latitude_arrays.py
@@ -158,7 +158,7 @@ def create_lon_lat_grids(acquisition, out_group=None,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('longitude-latitude.h5', driver='core',
+        fid = h5py.File('longitude-latitude.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -255,7 +255,7 @@ def create_lon_grid(acquisition, out_fname=None,
     """
     # Initialise the output files
     if out_fname is None:
-        fid = h5py.File('longitude.h5', driver='core',
+        fid = h5py.File('longitude.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = h5py.File(out_fname, 'w')
@@ -319,7 +319,7 @@ def create_lat_grid(acquisition, out_fname=None,
     """
     # Initialise the output files
     if out_fname is None:
-        fid = h5py.File('latitude.h5', driver='core',
+        fid = h5py.File('latitude.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = h5py.File(out_fname, 'w')

--- a/wagl/metadata.py
+++ b/wagl/metadata.py
@@ -425,4 +425,4 @@ def current_h5_metadata(fid: h5py.Group, dataset_path: str = ""):
                     fid.filename,
                     dataset_path))
 
-    return yaml.load(metadata[()].item())
+    return yaml.load(metadata[()].item(), Loader=yaml.FullLoader)

--- a/wagl/modtran.py
+++ b/wagl/modtran.py
@@ -273,7 +273,7 @@ def run_modtran(acquisitions, atmospherics_group, workflow, npoints, point,
 
     # determine the output group/file
     if out_group is None:
-        fid = h5py.File('atmospheric-results.h5', driver='core',
+        fid = h5py.File('atmospheric-results.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -428,7 +428,7 @@ def calculate_coefficients(atmospheric_results_group, out_group,
 
     # Initialise the output group/file
     if out_group is None:
-        fid = h5py.File('atmospheric-coefficients.h5', driver='core',
+        fid = h5py.File('atmospheric-coefficients.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -835,7 +835,7 @@ def link_atmospheric_results(input_targets, out_fname, npoints, workflow):
                     dname = ppjoin(grp_path, dset)
                     create_external_link(fname.path, dname, out_fname, dname)
 
-    with h5py.File(out_fname) as fid:
+    with h5py.File(out_fname, 'a') as fid:
         group = fid[GroupName.ATMOSPHERIC_RESULTS_GRP.value]
         group.attrs['npoints'] = npoints
         group.attrs['nbar_atmospherics'] = nbar_atmospherics

--- a/wagl/modtran.py
+++ b/wagl/modtran.py
@@ -661,7 +661,7 @@ def read_spectral_response(fname, spectral_range=None):
                                 'band_name': band},
                                index=wavelengths)
         df = response[band]
-        base_df.ix[df['wavelength'], 'response'] = df['response'].values
+        base_df.loc[df['wavelength'], 'response'] = df['response'].values
 
         response[band] = base_df
 

--- a/wagl/multifile_workflow.py
+++ b/wagl/multifile_workflow.py
@@ -929,7 +929,7 @@ class LinkwaglOutputs(luigi.Task):
                             create_external_link(fname, pth, out_fname,
                                                  new_path)
 
-            with h5py.File(out_fname) as fid:
+            with h5py.File(out_fname, 'a') as fid:
                 fid.attrs['level1_uri'] = self.level1
 
 

--- a/wagl/reflectance.py
+++ b/wagl/reflectance.py
@@ -212,7 +212,7 @@ def calculate_reflectance(acquisition, interpolation_group,
 
     # Initialise the output file
     if out_group is None:
-        fid = h5py.File('surface-reflectance.h5', driver='core',
+        fid = h5py.File('surface-reflectance.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -351,7 +351,7 @@ def link_standard_data(input_fnames, out_fname):
 
         # metadata
         with h5py.File(fname, 'r') as fid:
-            with h5py.File(out_fname) as out_fid:
+            with h5py.File(out_fname, 'a') as out_fid:
                 yaml_dname = DatasetName.NBAR_YAML.value
                 if yaml_dname in fid and yaml_dname not in out_fid:
                     fid.copy(yaml_dname, out_fid, name=yaml_dname)

--- a/wagl/satellite_solar_angles.py
+++ b/wagl/satellite_solar_angles.py
@@ -894,7 +894,7 @@ def calculate_angles(acquisition, lon_lat_group, out_group=None,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('satellite-solar-angles.h5', driver='core',
+        fid = h5py.File('satellite-solar-angles.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/slope_aspect.py
+++ b/wagl/slope_aspect.py
@@ -126,7 +126,7 @@ def slope_aspect_arrays(acquisition, dsm_group, buffer_distance,
     # Output the reprojected result
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('slope-aspect.h5', driver='core',
+        fid = h5py.File('slope-aspect.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/temperature.py
+++ b/wagl/temperature.py
@@ -116,7 +116,7 @@ def surface_brightness_temperature(acquisition, interpolation_group,
 
     # Initialise the output file
     if out_group is None:
-        fid = h5py.File('surface-temperature.h5', driver='core',
+        fid = h5py.File('surface-temperature.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group

--- a/wagl/terrain_shadow_masks.py
+++ b/wagl/terrain_shadow_masks.py
@@ -85,7 +85,7 @@ def self_shadow(incident_angles_group, exiting_angles_group, out_group=None,
 
     # Initialise the output file
     if out_group is None:
-        fid = h5py.File('self-shadow.h5', driver='core', backing_store=False)
+        fid = h5py.File('self-shadow.h5', 'w', driver='core', backing_store=False)
     else:
         fid = out_group
 
@@ -433,7 +433,7 @@ def calculate_cast_shadow(acquisition, dsm_group, satellite_solar_group,
 
     # Initialise the output file
     if out_group is None:
-        fid = h5py.File('cast-shadow-{}.h5'.format(source_dir), driver='core',
+        fid = h5py.File('cast-shadow-{}.h5'.format(source_dir), 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group
@@ -554,7 +554,7 @@ def combine_shadow_masks(self_shadow_group, cast_shadow_sun_group,
 
     # Initialise the output files
     if out_group is None:
-        fid = h5py.File('combined-shadow.h5', driver='core',
+        fid = h5py.File('combined-shadow.h5', 'w', driver='core',
                         backing_store=False)
     else:
         fid = out_group


### PR DESCRIPTION
Upgraded the codebase so that it can use GDAL-3 and Proj-6.

Also, a large number of other minor upgrades to resolve deprecation warnings, as well as those that had already been deprecated.

Full integration tests on a months worth of Landsat-8 data covering the Australian continent (~1000 scenes), resulted in very minimal differences in the output.