### PR TITLE
Resolved conflict between importlib.metadata and wagl.metadata

### DIFF
--- a/wagl/__init__.py
+++ b/wagl/__init__.py
@@ -2,12 +2,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 try:
-    from importlib import metadata
+    from importlib import metadata as _md
 except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
-    import importlib_metadata as metadata
+    import importlib_metadata as _md
 
 try:
-    __version__ = metadata.version(__name__)
-except metadata.PackageNotFoundError:
+    __version__ = _md.version(__name__)
+except _md.PackageNotFoundError:
     __version__ = "Not Installed"


### PR DESCRIPTION
A very minor fix to resolve a library conflict when loading metadata from importlib (which occurs in wagl.__init__), and metadata from wagl.