### PR TITLE
Resolve h5py string deserialization issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     "rasterio>1,!=1.0.3.post1,!=1.0.3",  # issue with /vsizip/ reader
     "fiona>=1.7.0",
     "shapely>=1.5.13",
-    "h5py>=2.5.0,<3.0.0",
+    "h5py>=2.5.0",
     "tables>=3.4.2",
     "pandas>=0.17.1",
     "geopandas>=0.1.1",

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -346,7 +346,14 @@ def write_dataframe(
             _dtype_name = re.sub(r"\[ns(?:,[^\]]+)?\]", "[ns]", _dtype_name)
         dtype_metadata["{}_dtype".format(idx_name)] = _dtype_name
         if _dtype_name == "object":
+            # sixy6e; there is probably a better way to do this now
             dtype.append((idx_name, VLEN_STRING))
+
+            # fix for handling strings post h5py-3.0.0
+            # converting to a numpy array to get the fixed length unicode
+            # and inserting the datatype as additional metadata for deserialisation
+            dtype_metadata["{}_dtype".format(idx_name)] = str(
+                idx_data.values.astype("U").dtype)
         elif "datetime64" in _dtype_name:
             dtype.append((idx_name, "int64"))
         else:
@@ -362,6 +369,10 @@ def write_dataframe(
         dtype_metadata["{}_dtype".format(col_name)] = _dtype_name
         if _dtype_name == "object":
             dtype.append((col_name, VLEN_STRING))
+
+            # metadata injection to resolve deserialisation of strings post h5py-3.0.0
+            dtype_metadata["{}_dtype".format(col_name)] = str(
+                df[col_name].values.astype("U").dtype)
         elif ("datetime64" in _dtype_name) or ("timedelta64" in _dtype_name):
             dtype.append((col_name, "int64"))
         else:

--- a/wagl/hdf5/__init__.py
+++ b/wagl/hdf5/__init__.py
@@ -353,7 +353,8 @@ def write_dataframe(
             # converting to a numpy array to get the fixed length unicode
             # and inserting the datatype as additional metadata for deserialisation
             dtype_metadata["{}_dtype".format(idx_name)] = str(
-                idx_data.values.astype("U").dtype)
+                idx_data.values.astype("U").dtype
+            )
         elif "datetime64" in _dtype_name:
             dtype.append((idx_name, "int64"))
         else:
@@ -372,7 +373,8 @@ def write_dataframe(
 
             # metadata injection to resolve deserialisation of strings post h5py-3.0.0
             dtype_metadata["{}_dtype".format(col_name)] = str(
-                df[col_name].values.astype("U").dtype)
+                df[col_name].values.astype("U").dtype
+            )
         elif ("datetime64" in _dtype_name) or ("timedelta64" in _dtype_name):
             dtype.append((col_name, "int64"))
         else:


### PR DESCRIPTION
Resolves issue #354 

A minor fix to resolve the string conversion issue.

What occurs now is the injection of a NumPy Unicode string type which is of the form "U{length}", so that after the string array is read a post-conversion takes place to convert from byte strings to NumPy Unicode rather than the plain _object_ type.