### PR TITLE
Fix gdal & OSR imports

### DIFF
--- a/tests/test_geobox.py
+++ b/tests/test_geobox.py
@@ -6,7 +6,7 @@ import unittest
 import numpy
 import numpy.testing as npt
 import h5py
-import gdal
+from osgeo import gdal
 import affine
 import rasterio as rio
 from osgeo import osr

--- a/tests/test_lon_lat.py
+++ b/tests/test_lon_lat.py
@@ -7,7 +7,7 @@ from os.path import join as pjoin, dirname, abspath
 from posixpath import join as ppjoin
 import numpy
 import numpy.testing as npt
-import osr
+from osgeo import osr
 
 from wagl.acquisition import acquisitions
 from wagl.constants import DatasetName, GroupName

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -8,7 +8,7 @@ import numpy
 from osgeo import gdal
 import h5py
 import rasterio as rio
-import osr
+from osgeo import osr
 import affine
 from affine import Affine
 from shapely.geometry import Polygon, box

--- a/wagl/geobox.py
+++ b/wagl/geobox.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function
 import math
 from math import radians
 import numpy
-import gdal
+from osgeo import gdal
 import h5py
 import rasterio as rio
 import osr

--- a/wagl/land_sea.py
+++ b/wagl/land_sea.py
@@ -4,7 +4,7 @@
 # -----------------------------------
 from __future__ import absolute_import, print_function
 import rasterio as rio
-import osr
+from osgeo import osr
 import numpy
 
 from wagl.geobox import GriddedGeoBox

--- a/wagl/longitude_latitude_arrays.py
+++ b/wagl/longitude_latitude_arrays.py
@@ -7,7 +7,7 @@ Longitude and Latitude 2D grid creation.
 from __future__ import absolute_import, print_function
 from functools import partial
 import numpy
-import osr
+from osgeo import osr
 import h5py
 
 from wagl.constants import DatasetName, GroupName

--- a/wagl/tiling.py
+++ b/wagl/tiling.py
@@ -15,7 +15,7 @@
 # ===============================================================================
 
 from __future__ import absolute_import, print_function
-import gdal
+from osgeo import gdal
 import numpy
 
 

--- a/wagl/unittesting_tools.py
+++ b/wagl/unittesting_tools.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function
 import unittest
 
 import numpy
-import osr
+from osgeo import osr
 
 from wagl.geobox import GriddedGeoBox
 


### PR DESCRIPTION
Fixed several imports to include `from osgeo import ...` as per GDAL examples.